### PR TITLE
Add -h for the help option

### DIFF
--- a/lib/clamp/option/declaration.rb
+++ b/lib/clamp/option/declaration.rb
@@ -40,7 +40,7 @@ module Clamp
         documented_options + standard_options
       end
 
-      HELP_OPTION = Clamp::Option.new("--help", :flag, "print help", :attribute_name => :help_requested)
+      HELP_OPTION = Clamp::Option.new([ "-h", "--help" ], :flag, "print help", :attribute_name => :help_requested)
 
       def standard_options
         [HELP_OPTION]


### PR DESCRIPTION
Allows you to get the help text using `-h`, for example:

```
$ speak -h
Usage:
    speak [OPTIONS] WORDS ...

Arguments:
    WORDS ...                     the thing to say

Options:
    --loud                        say it loud
    -n, --iterations N            say it N times (default: 1)
    -h, --help                    print help
```
