### PR TITLE
UsageErrorWithHelp, use it per default when SUBCOMMAND is missing

### DIFF
--- a/lib/clamp/command.rb
+++ b/lib/clamp/command.rb
@@ -91,8 +91,12 @@ module Clamp
 
     private
 
-    def signal_usage_error(message)
-      e = UsageError.new(message, self)
+    def signal_usage_error(message, with_help = false)
+      e = if with_help
+            UsageErrorWithHelp.new(message, self)
+          else
+            UsageError.new(message, self)
+          end
       e.set_backtrace(caller)
       raise e
     end
@@ -117,6 +121,10 @@ module Clamp
       def run(invocation_path = File.basename($0), arguments = ARGV, context = {})
         begin 
           new(invocation_path, context).run(arguments)
+        rescue Clamp::UsageErrorWithHelp => e
+          $stderr.puts "ERROR: #{e.message}\n\n"
+          puts e.command.help
+          exit(1)
         rescue Clamp::UsageError => e
           $stderr.puts "ERROR: #{e.message}"
           $stderr.puts ""

--- a/lib/clamp/errors.rb
+++ b/lib/clamp/errors.rb
@@ -14,6 +14,9 @@ module Clamp
   # raise to signal incorrect command usage
   class UsageError < Error; end
 
+  # similar to UsageError, but triggers help before exiting
+  class UsageErrorWithHelp < UsageError; end
+
   # raise to request usage help
   class HelpWanted < Error
 
@@ -22,5 +25,4 @@ module Clamp
     end
 
   end
-
 end

--- a/lib/clamp/parameter/parsing.rb
+++ b/lib/clamp/parameter/parsing.rb
@@ -6,13 +6,16 @@ module Clamp
       protected
       
       def parse_parameters
-
         self.class.parameters.each do |parameter|
           begin
             value = parameter.consume(remaining_arguments)
             send("#{parameter.attribute_name}=", value) unless value.nil?
           rescue ArgumentError => e
-            signal_usage_error "parameter '#{parameter.name}': #{e.message}"
+            if parameter.name != "SUBCOMMAND"
+              signal_usage_error "parameter '#{parameter.name}': #{e.message}"
+            else
+              signal_usage_error "no subcommand specified", true
+            end
           end
         end
 


### PR DESCRIPTION
I went for the only implementation I could think of, given that the subcommand parameter has nothing specific to it save its name.

I'm sad not to be able to push spec updates with this change - previous behavior wasn't spec'd either - and I couldn't really figure out how to spec it properly.
