### PR TITLE
Fix bug with default values for multivalued parameters

### DIFF
--- a/lib/clamp/parameter.rb
+++ b/lib/clamp/parameter.rb
@@ -9,7 +9,7 @@ module Clamp
       @description = description
       infer_attribute_name_and_multiplicity
       if options.has_key?(:attribute_name)
-        @attribute_name = options[:attribute_name].to_s 
+        @attribute_name = options[:attribute_name].to_s
       end
       if options.has_key?(:default)
         @default_value = options[:default]
@@ -17,7 +17,7 @@ module Clamp
     end
 
     attr_reader :name, :attribute_name
-    
+
     def help_lhs
       name
     end
@@ -27,16 +27,18 @@ module Clamp
         raise ArgumentError, "no value provided"
       end
       if multivalued?
-        arguments.shift(arguments.length)
+        if arguments.length > 0
+          arguments.shift(arguments.length)
+        end
       else
         arguments.shift
       end
     end
-    
+
     private
 
     NAME_PATTERN = "([A-Za-z0-9_-]+)"
-    
+
     def infer_attribute_name_and_multiplicity
       case @name
       when /^\[#{NAME_PATTERN}\]$/
@@ -56,7 +58,7 @@ module Clamp
       end
       @attribute_name = @attribute_name.downcase.tr('-', '_')
     end
-    
+
     def multivalued?
       @multivalued
     end
@@ -64,7 +66,7 @@ module Clamp
     def required?
       @required
     end
-    
+
   end
 
 end

--- a/spec/clamp/command_spec.rb
+++ b/spec/clamp/command_spec.rb
@@ -301,7 +301,7 @@ describe Clamp::Command do
         @command.help.should =~ %r(--flavour FLAVOUR +Flavour of the month)
         @command.help.should =~ %r(--color COLOR +Preferred hue)
       end
-      
+
       it "handles new lines in option descriptions" do
         @command.help.should =~ %r(--\[no-\]nuts +Nuts \(or not\)\n +May include nuts)
       end
@@ -387,6 +387,26 @@ describe Clamp::Command do
 
         it "describes the default value" do
           @command.help.should include("direction (default: \"west\")")
+        end
+
+      end
+
+    end
+
+    describe "with :default values for multivalued" do
+
+      before do
+        @command.class.parameter "[ORIENTATIONS] ...", "directions", :default => ["west", "east"]
+      end
+
+      it "sets the specified default values array" do
+        @command.orientation.should == ["west", "east"]
+      end
+
+      describe "#help" do
+
+        it "describes the default values" do
+          @command.help.should include("directions (default: [\"west\", \"east\"])")
         end
 
       end
@@ -497,9 +517,9 @@ describe Clamp::Command do
       it "includes parameter details" do
         @command.help.should =~ %r(X +x)
         @command.help.should =~ %r(Y +y)
-        @command.help.should =~ %r(\[Z\] +z \(default: "ZZZ"\))        
+        @command.help.should =~ %r(\[Z\] +z \(default: "ZZZ"\))
       end
-      
+
       it "handles new lines in option descriptions" do
         @command.help.should =~ %r(X +x\n +xx)
       end


### PR DESCRIPTION
Add appropriate specs with array asserts as default and array in help
output
