### PR TITLE
Options are parsed more than once when subcommands are instantiated

### DIFF
--- a/lib/clamp/subcommand/parsing.rb
+++ b/lib/clamp/subcommand/parsing.rb
@@ -29,8 +29,8 @@ module Clamp
         subcommand = subcommand_class.new("#{invocation_path} #{name}", context)
         self.class.recognised_options.each do |option|
           option_set = instance_variable_defined?(option.ivar_name)
-          if option_set && subcommand.respond_to?(option.write_method)
-            subcommand.send(option.write_method, self.send(option.read_method))
+          if option_set
+            subcommand.instance_variable_set(option.ivar_name, self.send(option.read_method))
           end
         end
         subcommand

--- a/spec/clamp/command_group_spec.rb
+++ b/spec/clamp/command_group_spec.rb
@@ -243,4 +243,25 @@ describe Clamp::Command do
 
   end
 
+  describe "with a subcommand, with options" do
+
+    given_command 'weeheehee' do
+      option '--json', 'JSON', 'a json blob' do |option|
+        print "parsing!"
+        option
+      end
+
+      subcommand 'woohoohoo', 'like weeheehee but with more o' do
+        def execute
+        end
+      end
+    end
+
+    it "only parses options once" do
+      @command.run(['--json', '{"a":"b"}', 'woohoohoo'])
+      stdout.should == 'parsing!'
+    end
+
+  end
+
 end


### PR DESCRIPTION
Not sure what the exact intention is of blocks attached to options to parse options, but when you run a subcommand in clamp, all of the options for its parent command are parsed again.

This makes using option blocks for doing more complicated transforms (reading/parsing files for example) trickier, for example (in cmd.rb):

require 'clamp'

class FileShower < Clamp::Command
  option '--file', 'FILENAME', 'some file to read in' do |option|
    File.read(option)
  end

  subcommand 'show-file', 'show the file' do
    def execute
      puts file
    end
  end
end

FileShower.run

Running `cmd.rb --file file show-file` will break as the block attached the --file option is run twice. I can add a guard clause to the block, but this feels hacky.

The fix I've written for this is to set the instance variables on subcommands directly when instantiating subcommands - not the cleanest perhaps but it works. An alternative might be to do the conversion in extract_value.
