### PR TITLE
Provide Command#banner DSL Around Script Description

### DIFF
--- a/examples/speak
+++ b/examples/speak
@@ -6,7 +6,7 @@ require "clamp"
 
 class SpeakCommand < Clamp::Command
 
-  self.description = %{
+  banner %{
     Say something.
   }
 

--- a/lib/clamp/help.rb
+++ b/lib/clamp/help.rb
@@ -20,6 +20,10 @@ module Clamp
       @description.strip!
     end
 
+    def banner(description)
+      self.description = description
+    end
+
     attr_reader :description
 
     def derived_usage_description

--- a/spec/clamp/command_spec.rb
+++ b/spec/clamp/command_spec.rb
@@ -764,11 +764,11 @@ describe Clamp::Command do
 
   end
 
-  describe "with a description" do
+  describe "with a banner" do
 
     given_command("punt") do
 
-      self.description = <<-EOF
+      banner <<-EOF
         Punt is an example command.  It doesn't do much, really.
 
         The prefix at the beginning of this description should be normalised
@@ -779,7 +779,7 @@ describe Clamp::Command do
 
     describe "#help" do
 
-      it "includes the description" do
+      it "includes the banner" do
         command.help.should =~ /^  Punt is an example command/
         command.help.should =~ /^  The prefix/
       end


### PR DESCRIPTION
This more closely matches the look and feel of the other configuration methods, like `option` and `parameter`. The behavior remains identical, and will not interfere with existing usage of `self.description` in current scripts.

See this from examples/speak for usage:

``` ruby
class SpeakCommand < Clamp::Command

  banner %{
    Say something.
  }

  option "--loud", :flag, "say it loud"
  option ["-n", "--iterations"], "N", "say it N times", :default => 1 do |s|
    Integer(s)
  end

  parameter "WORDS ...", "the thing to say", :attribute_name => :words
  # and so on
```
