### PR TITLE
Allow inject you own help Builder

### DIFF
--- a/lib/clamp/help.rb
+++ b/lib/clamp/help.rb
@@ -36,8 +36,8 @@ module Clamp
       declared_usage_descriptions || [derived_usage_description]
     end
 
-    def help(invocation_path)
-      help = Builder.new
+    def help(invocation_path, builder = Builder.new)
+      help = builder
       help.add_usage(invocation_path, usage_descriptions)
       help.add_description(description)
       if has_parameters?


### PR DESCRIPTION
If you want to customize help output, e.g. when you have advanced
options that you don't want to display by default you can change your
Clamp::Command.help method to set yor own help builder.
