### PR TITLE
I18n support

### DIFF
--- a/lib/clamp/attribute/instance.rb
+++ b/lib/clamp/attribute/instance.rb
@@ -72,7 +72,7 @@ module Clamp
         begin
           take(value)
         rescue ArgumentError => e
-          command.send(:signal_usage_error, "$#{attribute.environment_variable}: #{e.message}")
+          raise EnvVariableParseError.new("$#{attribute.environment_variable}: #{e.message}", command, attribute.environment_variable, e)
         end
       end
 

--- a/lib/clamp/command.rb
+++ b/lib/clamp/command.rb
@@ -91,7 +91,7 @@ module Clamp
 
     def handle_remaining_arguments
       unless remaining_arguments.empty?
-        signal_usage_error "too many arguments"
+        raise TooManyArgumentsError.new("too many arguments", self)
       end
     end
 

--- a/lib/clamp/errors.rb
+++ b/lib/clamp/errors.rb
@@ -17,6 +17,62 @@ module Clamp
   # raise to signal incorrect command usage
   class UsageError < RuntimeError; end
 
+  # specific usage exceptions
+  class TooManyArgumentsError < UsageError; end
+
+  class AttributeParseError < UsageError
+
+    def initialize(message, command, switch, original_exception)
+      super(message, command)
+      @switch = switch
+      @original_exception = original_exception
+    end
+
+    attr_reader :switch, :original_exception
+
+  end
+
+  class OptionParseError < AttributeParseError; end
+  class ParameterParseError < AttributeParseError; end
+
+  class EnvVariableParseError < UsageError
+
+    def initialize(message, command, env_variable_name, original_exception)
+      super(message, command)
+      @env_variable_name = env_variable_name
+      @original_exception = original_exception
+    end
+
+    attr_reader :env_variable_name, :original_exception
+
+  end
+
+  class RequiredOptionError < UsageError
+
+    def initialize(message, command, option)
+      super(message, command)
+      @option = option
+    end
+
+    attr_reader :option
+
+  end
+
+
+  class UnrecognisedAttributeError < UsageError
+
+    def initialize(message, command, attribute_name)
+      super(message, command)
+      @attribute_name = attribute_name
+    end
+
+    attr_reader :attribute_name
+
+  end
+
+  class UnrecognisedOptionError < UnrecognisedAttributeError; end
+  class UnrecognisedSubcommandError < UnrecognisedAttributeError; end
+
   # raise to request usage help
   class HelpWanted < RuntimeError
 

--- a/lib/clamp/help.rb
+++ b/lib/clamp/help.rb
@@ -61,7 +61,7 @@ module Clamp
       end
 
       def add_usage(invocation_path, usage_descriptions)
-        puts "Usage:"
+        puts usage_heading
         usage_descriptions.each do |usage|
           puts "    #{invocation_path} #{usage}".rstrip
         end
@@ -85,6 +85,12 @@ module Clamp
             label = ''
           end
         end
+      end
+
+      protected
+
+      def usage_heading
+        "Usage:"
       end
 
       private

--- a/lib/clamp/option/parsing.rb
+++ b/lib/clamp/option/parsing.rb
@@ -31,7 +31,7 @@ module Clamp
           begin
             option.of(self).take(value)
           rescue ArgumentError => e
-            signal_usage_error "option '#{switch}': #{e.message}"
+            raise OptionParseError.new("option '#{switch}': #{e.message}", self, switch, e)
           end
 
         end
@@ -50,7 +50,7 @@ module Clamp
               message += " (or env #{option.environment_variable})"
             end
             message += " is required"
-            signal_usage_error message
+            raise RequiredOptionError.new(message, self, option)
           end
         end
       end
@@ -59,7 +59,7 @@ module Clamp
 
       def find_option(switch)
         self.class.find_option(switch) ||
-        signal_usage_error("Unrecognised option '#{switch}'")
+        raise(UnrecognisedOptionError.new("Unrecognised option '#{switch}'", self, switch))
       end
 
     end

--- a/lib/clamp/parameter/parsing.rb
+++ b/lib/clamp/parameter/parsing.rb
@@ -13,7 +13,7 @@ module Clamp
               parameter.of(self).take(value)
             end
           rescue ArgumentError => e
-            signal_usage_error "parameter '#{parameter.name}': #{e.message}"
+            raise ParameterParseError.new("parameter '#{parameter.name}': #{e.message}", self, parameter.name, e)
           end
         end
 

--- a/lib/clamp/subcommand/execution.rb
+++ b/lib/clamp/subcommand/execution.rb
@@ -25,7 +25,7 @@ module Clamp
       end
 
       def find_subcommand_class(name)
-        subcommand_def = self.class.find_subcommand(name) || signal_usage_error("No such sub-command '#{name}'")
+        subcommand_def = self.class.find_subcommand(name) || raise(UnrecognisedSubcommandError.new("No such sub-command '#{name}'", self, name))
         subcommand_def.subcommand_class
       end
 


### PR DESCRIPTION
- UsageError split into more specific exceptions with parameters. It will enable projects using Clamp to catch such exceptions and print their own translated strings.
- Heading in HelpBuilder extracted to a function to make overriding easier.
