### PR TITLE
 I18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,25 @@ Options:
     -h, --help                    print help
 ```
 
+Localization
+------------
+
+Clamp comes with support for overriding strings with custom translations. You can use localization library of your choice and override the strings at startup.
+
+Example usage:
+```ruby
+require 'gettext'
+
+Clamp.messages = {
+  :too_many_arguments =>       _("too many arguments"),
+  :option_required =>          _("option '%<option>s' is required"),
+  :option_or_env_required =>   _("option '%<option>s' (or env %<env>s) is required"),
+  :option_argument_error =>    _("option '%<switch>s': %<message>s")
+  # ...
+}
+```
+See [messages.rb](https://github.com/mdub/clamp/blob/master/lib/clamp/messages.rb) for full list of available messages.
+
 License
 -------
 

--- a/lib/clamp/attribute/instance.rb
+++ b/lib/clamp/attribute/instance.rb
@@ -69,7 +69,7 @@ module Clamp
         begin
           take(value)
         rescue ArgumentError => e
-          command.send(:signal_usage_error, "$#{attribute.environment_variable}: #{e.message}")
+          command.send(:signal_usage_error, Clamp.message(:env_argument_error, :env => attribute.environment_variable, :message => e.message))
         end
       end
 

--- a/lib/clamp/command.rb
+++ b/lib/clamp/command.rb
@@ -1,3 +1,4 @@
+require 'clamp/messages'
 require 'clamp/errors'
 require 'clamp/help'
 require 'clamp/option/declaration'
@@ -91,7 +92,7 @@ module Clamp
 
     def handle_remaining_arguments
       unless remaining_arguments.empty?
-        signal_usage_error "too many arguments"
+        signal_usage_error Clamp.message(:too_many_arguments)
       end
     end
 

--- a/lib/clamp/help.rb
+++ b/lib/clamp/help.rb
@@ -1,4 +1,5 @@
 require 'stringio'
+require 'clamp/messages'
 
 module Clamp
 
@@ -41,12 +42,12 @@ module Clamp
       help.add_usage(invocation_path, usage_descriptions)
       help.add_description(description)
       if has_parameters?
-        help.add_list("Parameters", parameters)
+        help.add_list(Clamp.message(:parameters_heading), parameters)
       end
       if has_subcommands?
-        help.add_list("Subcommands", recognised_subcommands)
+        help.add_list(Clamp.message(:subcommands_heading), recognised_subcommands)
       end
-      help.add_list("Options", recognised_options)
+      help.add_list(Clamp.message(:options_heading), recognised_options)
       help.string
     end
 
@@ -90,7 +91,7 @@ module Clamp
       protected
 
       def usage_heading
-        "Usage:"
+        Clamp.message(:usage_heading) + ":"
       end
 
       private

--- a/lib/clamp/help.rb
+++ b/lib/clamp/help.rb
@@ -62,7 +62,7 @@ module Clamp
       end
 
       def add_usage(invocation_path, usage_descriptions)
-        puts usage_heading
+        puts Clamp.message(:usage_heading) + ":"
         usage_descriptions.each do |usage|
           puts "    #{invocation_path} #{usage}".rstrip
         end
@@ -86,12 +86,6 @@ module Clamp
             label = ''
           end
         end
-      end
-
-      protected
-
-      def usage_heading
-        Clamp.message(:usage_heading) + ":"
       end
 
       private

--- a/lib/clamp/help.rb
+++ b/lib/clamp/help.rb
@@ -61,7 +61,7 @@ module Clamp
       end
 
       def add_usage(invocation_path, usage_descriptions)
-        puts "Usage:"
+        puts usage_heading
         usage_descriptions.each do |usage|
           puts "    #{invocation_path} #{usage}".rstrip
         end
@@ -85,6 +85,12 @@ module Clamp
             label = ''
           end
         end
+      end
+
+      protected
+
+      def usage_heading
+        "Usage:"
       end
 
       private

--- a/lib/clamp/messages.rb
+++ b/lib/clamp/messages.rb
@@ -10,6 +10,10 @@ module Clamp
       format_string(messages.fetch(key), options)
     end
 
+    def clear_messages!
+      init_default_messages
+    end
+
     private
 
     DEFAULTS = {
@@ -30,9 +34,13 @@ module Clamp
 
     def messages
       unless defined?(@messages)
-        @messages = DEFAULTS
+        init_default_messages
       end
       @messages
+    end
+
+    def init_default_messages
+      @messages = DEFAULTS.clone
     end
 
     begin

--- a/lib/clamp/messages.rb
+++ b/lib/clamp/messages.rb
@@ -30,14 +30,23 @@ module Clamp
 
   private
 
-  # string formatting for ruby 1.8
-  def self.format_string(string, params)
-    array_params = string.scan(/%[<{]([^>}]*)[>}]/).collect do |name|
-      name = name[0]
-      params[name.to_s] || params[name.to_sym]
+  if (("%{foo}" % {:foo => "bar"}) == "bar")
+
+    def self.format_string(format, params = {})
+      format % params
     end
 
-    string.gsub(/%[<]([^>]*)[>]/, '%').gsub(/%[{]([^}]*)[}]/, '%s') % array_params
+  else
+
+    # string formatting for ruby 1.8
+    def self.format_string(format, params = {})
+      array_params = format.scan(/%[<{]([^>}]*)[>}]/).collect do |name|
+        name = name[0]
+        params[name.to_s] || params[name.to_sym]
+      end
+      format.gsub(/%[<]([^>]*)[>]/, '%').gsub(/%[{]([^}]*)[}]/, '%s') % array_params
+    end
+
   end
 
 end

--- a/lib/clamp/messages.rb
+++ b/lib/clamp/messages.rb
@@ -35,13 +35,15 @@ module Clamp
       @messages
     end
 
-    if (("%{foo}" % {:foo => "bar"}) == "bar")
+    begin
+
+      ("%{foo}" % {:foo => "bar"}) # test Ruby 1.9 string interpolation
 
       def format_string(format, params = {})
         format % params
       end
 
-    else
+    rescue ArgumentError
 
       # string formatting for ruby 1.8
       def format_string(format, params = {})

--- a/lib/clamp/messages.rb
+++ b/lib/clamp/messages.rb
@@ -1,52 +1,58 @@
 module Clamp
 
-  def self.messages=(messages)
-    @user_defined_messages = messages
-  end
+  module Messages
 
-  def self.message(key, options={})
-    @user_defined_messages ||= {}
-    msg = @user_defined_messages[key] || messages[key]
-    format_string(msg, options)
-  end
-
-  def self.messages
-    {
-      :too_many_arguments => "too many arguments",
-      :option_required => "option '%<option>s' is required",
-      :option_or_env_required => "option '%<option>s' (or env %<env>s) is required",
-      :option_argument_error => "option '%<switch>s': %<message>s",
-      :parameter_argument_error => "parameter '%<param>s': %<message>s",
-      :env_argument_error => "$%<env>s: %<message>s",
-      :unrecognised_option => "Unrecognised option '%<switch>s'",
-      :no_such_subcommand => "No such sub-command '%<name>s'",
-      :no_value_provided => "no value provided",
-      :usage_heading => "Usage",
-      :parameters_heading => "Parameters",
-      :subcommands_heading => "Subcommands",
-      :options_heading => "Options"
-    }
-  end
-
-  private
-
-  if (("%{foo}" % {:foo => "bar"}) == "bar")
-
-    def self.format_string(format, params = {})
-      format % params
+    def messages=(messages)
+      @user_defined_messages = messages
     end
 
-  else
+    def message(key, options={})
+      @user_defined_messages ||= {}
+      msg = @user_defined_messages[key] || messages[key]
+      format_string(msg, options)
+    end
 
-    # string formatting for ruby 1.8
-    def self.format_string(format, params = {})
-      array_params = format.scan(/%[<{]([^>}]*)[>}]/).collect do |name|
-        name = name[0]
-        params[name.to_s] || params[name.to_sym]
+    def messages
+      {
+        :too_many_arguments => "too many arguments",
+        :option_required => "option '%<option>s' is required",
+        :option_or_env_required => "option '%<option>s' (or env %<env>s) is required",
+        :option_argument_error => "option '%<switch>s': %<message>s",
+        :parameter_argument_error => "parameter '%<param>s': %<message>s",
+        :env_argument_error => "$%<env>s: %<message>s",
+        :unrecognised_option => "Unrecognised option '%<switch>s'",
+        :no_such_subcommand => "No such sub-command '%<name>s'",
+        :no_value_provided => "no value provided",
+        :usage_heading => "Usage",
+        :parameters_heading => "Parameters",
+        :subcommands_heading => "Subcommands",
+        :options_heading => "Options"
+      }
+    end
+
+    private
+
+    if (("%{foo}" % {:foo => "bar"}) == "bar")
+
+      def format_string(format, params = {})
+        format % params
       end
-      format.gsub(/%[<]([^>]*)[>]/, '%').gsub(/%[{]([^}]*)[}]/, '%s') % array_params
+
+    else
+
+      # string formatting for ruby 1.8
+      def format_string(format, params = {})
+        array_params = format.scan(/%[<{]([^>}]*)[>}]/).collect do |name|
+          name = name[0]
+          params[name.to_s] || params[name.to_sym]
+        end
+        format.gsub(/%[<]([^>]*)[>]/, '%').gsub(/%[{]([^}]*)[}]/, '%s') % array_params
+      end
+
     end
 
   end
+
+  extend Messages
 
 end

--- a/lib/clamp/messages.rb
+++ b/lib/clamp/messages.rb
@@ -2,35 +2,38 @@ module Clamp
 
   module Messages
 
-    def messages=(messages)
-      @user_defined_messages = messages
+    def messages=(new_messages)
+      messages.merge!(new_messages)
     end
 
     def message(key, options={})
-      @user_defined_messages ||= {}
-      msg = @user_defined_messages[key] || messages[key]
-      format_string(msg, options)
-    end
-
-    def messages
-      {
-        :too_many_arguments => "too many arguments",
-        :option_required => "option '%<option>s' is required",
-        :option_or_env_required => "option '%<option>s' (or env %<env>s) is required",
-        :option_argument_error => "option '%<switch>s': %<message>s",
-        :parameter_argument_error => "parameter '%<param>s': %<message>s",
-        :env_argument_error => "$%<env>s: %<message>s",
-        :unrecognised_option => "Unrecognised option '%<switch>s'",
-        :no_such_subcommand => "No such sub-command '%<name>s'",
-        :no_value_provided => "no value provided",
-        :usage_heading => "Usage",
-        :parameters_heading => "Parameters",
-        :subcommands_heading => "Subcommands",
-        :options_heading => "Options"
-      }
+      format_string(messages.fetch(key), options)
     end
 
     private
+
+    DEFAULTS = {
+      :too_many_arguments => "too many arguments",
+      :option_required => "option '%<option>s' is required",
+      :option_or_env_required => "option '%<option>s' (or env %<env>s) is required",
+      :option_argument_error => "option '%<switch>s': %<message>s",
+      :parameter_argument_error => "parameter '%<param>s': %<message>s",
+      :env_argument_error => "$%<env>s: %<message>s",
+      :unrecognised_option => "Unrecognised option '%<switch>s'",
+      :no_such_subcommand => "No such sub-command '%<name>s'",
+      :no_value_provided => "no value provided",
+      :usage_heading => "Usage",
+      :parameters_heading => "Parameters",
+      :subcommands_heading => "Subcommands",
+      :options_heading => "Options"
+    }
+
+    def messages
+      unless defined?(@messages)
+        @messages = DEFAULTS
+      end
+      @messages
+    end
 
     if (("%{foo}" % {:foo => "bar"}) == "bar")
 

--- a/lib/clamp/messages.rb
+++ b/lib/clamp/messages.rb
@@ -1,0 +1,39 @@
+module Clamp
+
+  def self.messages=(messages)
+    @user_defined_messages = messages
+  end
+
+  def self.message(key, options={})
+    @user_defined_messages ||= {}
+    msg = @user_defined_messages[key] || messages[key]
+    format_string(msg, options)
+  end
+
+  def self.messages
+    {
+      :too_many_arguments => "too many arguments",
+      :option_required => "option '%<option>s' is required",
+      :option_or_env_required => "option '%<option>s' (or env %<env>s) is required",
+      :option_argument_error => "option '%<switch>s': %<message>s",
+      :parameter_argument_error => "parameter '%<param>s': %<message>s",
+      :env_argument_error => "$%<env>s: %<message>s",
+      :unrecognised_option => "Unrecognised option '%<switch>s'",
+      :no_such_subcommand => "No such sub-command '%<name>s'",
+      :no_value_provided => "no value provided"
+    }
+  end
+
+  private
+
+  # string formatting for ruby 1.8
+  def self.format_string(string, params)
+    array_params = string.scan(/%[<{]([^>}]*)[>}]/).collect do |name|
+      name = name[0]
+      params[name.to_s] || params[name.to_sym]
+    end
+
+    string.gsub(/%[<]([^>]*)[>]/, '%').gsub(/%[{]([^}]*)[}]/, '%s') % array_params
+  end
+
+end

--- a/lib/clamp/messages.rb
+++ b/lib/clamp/messages.rb
@@ -20,7 +20,11 @@ module Clamp
       :env_argument_error => "$%<env>s: %<message>s",
       :unrecognised_option => "Unrecognised option '%<switch>s'",
       :no_such_subcommand => "No such sub-command '%<name>s'",
-      :no_value_provided => "no value provided"
+      :no_value_provided => "no value provided",
+      :usage_heading => "Usage",
+      :parameters_heading => "Parameters",
+      :subcommands_heading => "Subcommands",
+      :options_heading => "Options"
     }
   end
 

--- a/lib/clamp/option/parsing.rb
+++ b/lib/clamp/option/parsing.rb
@@ -31,7 +31,7 @@ module Clamp
           begin
             option.of(self).take(value)
           rescue ArgumentError => e
-            signal_usage_error "option '#{switch}': #{e.message}"
+            signal_usage_error Clamp.message(:option_argument_error, :switch => switch, :message => e.message)
           end
 
         end
@@ -45,11 +45,11 @@ module Clamp
         self.class.recognised_options.each do |option|
           # If this option is required and the value is nil, there's an error.
           if option.required? and send(option.attribute_name).nil?
-            message = "option '#{option.switches.first}'"
             if option.environment_variable
-              message += " (or env #{option.environment_variable})"
+              message = Clamp.message(:option_or_env_required, :option => option.switches.first, :env => option.environment_variable)
+            else
+              message = Clamp.message(:option_required, :option => option.switches.first)
             end
-            message += " is required"
             signal_usage_error message
           end
         end
@@ -59,7 +59,7 @@ module Clamp
 
       def find_option(switch)
         self.class.find_option(switch) ||
-        signal_usage_error("Unrecognised option '#{switch}'")
+        signal_usage_error(Clamp.message(:unrecognised_option, :switch => switch))
       end
 
     end

--- a/lib/clamp/parameter/definition.rb
+++ b/lib/clamp/parameter/definition.rb
@@ -22,7 +22,7 @@ module Clamp
       end
 
       def consume(arguments)
-        raise ArgumentError, "no value provided" if required? && arguments.empty?
+        raise ArgumentError, Clamp.message(:no_value_provided) if required? && arguments.empty?
         arguments.shift(multivalued? ? arguments.length : 1)
       end
 

--- a/lib/clamp/parameter/parsing.rb
+++ b/lib/clamp/parameter/parsing.rb
@@ -13,7 +13,7 @@ module Clamp
               parameter.of(self).take(value)
             end
           rescue ArgumentError => e
-            signal_usage_error "parameter '#{parameter.name}': #{e.message}"
+            signal_usage_error Clamp.message(:parameter_argument_error, :param => parameter.name, :message => e.message)
           end
         end
 

--- a/lib/clamp/subcommand/execution.rb
+++ b/lib/clamp/subcommand/execution.rb
@@ -25,7 +25,7 @@ module Clamp
       end
 
       def find_subcommand_class(name)
-        subcommand_def = self.class.find_subcommand(name) || signal_usage_error("No such sub-command '#{name}'")
+        subcommand_def = self.class.find_subcommand(name) || signal_usage_error(Clamp.message(:no_such_subcommand, :name => name))
         subcommand_def.subcommand_class
       end
 

--- a/spec/clamp/messages_spec.rb
+++ b/spec/clamp/messages_spec.rb
@@ -1,0 +1,44 @@
+
+require 'spec_helper'
+
+describe Clamp::Messages do
+
+  describe "message" do
+    before do
+      Clamp.messages = {
+        :too_many_arguments => "Way too many!",
+        :custom_message => "Say %<what>s to %<whom>s"
+      }
+    end
+
+    after do
+      Clamp.clear_messages!
+    end
+
+    it "allows setting custom messages" do
+      expect(Clamp.message(:too_many_arguments)).to eql "Way too many!"
+    end
+
+    it "fallbacks to a default message" do
+      expect(Clamp.message(:no_value_provided)).to eql "no value provided"
+    end
+
+    it "formats the message" do
+      expect(Clamp.message(:custom_message, :what => "hello", :whom => "Clamp")).to eql "Say hello to Clamp"
+    end
+  end
+
+  describe "clear_messages!" do
+    it "clears messages to the defualt state" do
+      default_msg = Clamp.message(:too_many_arguments).clone
+
+      Clamp.messages = {
+        :too_many_arguments => "Way too many!"
+      }
+      Clamp.clear_messages!
+
+      expect(Clamp.message(:too_many_arguments)).to eql default_msg
+    end
+  end
+
+end


### PR DESCRIPTION
- Heading in HelpBuilder extracted to a function to make overriding easier.
- Translation table for overriding messages. Usage is:
```ruby
Clamp.messages = {
  :too_many_arguments => "..."
}
```