### PR TITLE
Add support for hidden options

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ option "--format", "FORMAT", "output format", :multivalued => true
 
 The underlying attribute becomes an Array, and the suffix "`_list`" is appended to the default attribute name.  In this case, an attribute called "`format_list`" would be generated (unless you override the default by specifying an `:attribute_name`).
 
+### Hidden options
+
+Declaring an option "`:hidden`" will cause it to be hidden from `--help` output.
+
+```ruby
+option "--some-option", "VALUE", "Just a little option", :hidden => true
+```
+
+
 Declaring parameters
 --------------------
 

--- a/lib/clamp/attribute/definition.rb
+++ b/lib/clamp/attribute/definition.rb
@@ -15,6 +15,9 @@ module Clamp
         if options.has_key?(:environment_variable)
           @environment_variable = options[:environment_variable]
         end
+        if options.has_key?(:hidden)
+          @hidden = options[:hidden]
+        end
       end
 
       attr_reader :description, :environment_variable
@@ -55,6 +58,10 @@ module Clamp
 
       def required?
         @required
+      end
+
+      def hidden?
+        @hidden
       end
 
       def attribute_name

--- a/lib/clamp/help.rb
+++ b/lib/clamp/help.rb
@@ -78,7 +78,7 @@ module Clamp
 
       def add_list(heading, items)
         puts "\n#{heading}:"
-        items.each do |item|
+        items.reject { |i| i.respond_to?(:hidden?) && i.hidden? }.each do |item|
           label, description = item.help
           description.each_line do |line|
             puts DETAIL_FORMAT % [label, line]

--- a/spec/clamp/option/definition_spec.rb
+++ b/spec/clamp/option/definition_spec.rb
@@ -257,4 +257,33 @@ describe Clamp::Option::Definition do
       end.to raise_error(ArgumentError)
     end
   end
+
+  describe "a hidden option" do
+    let(:option) { described_class.new("--unseen", :flag, "Something", :hidden => true) }
+    it "is hidden" do
+      expect(option).to be_hidden
+    end
+  end
+
+  describe "a hidden option in a command" do
+    let(:command_class) do
+      Class.new(Clamp::Command) do
+        option "--unseen", :flag, "Something", :hidden => true
+
+        def execute
+          # this space intentionally left blank
+        end
+      end
+    end
+
+    it "is not shown in the help" do
+      expect(command_class.help("foo")).not_to match /^ +--unseen +Something$/
+    end
+
+    it "sets the expected accessor" do
+      command = command_class.new("foo")
+      command.run(["--unseen"])
+      expect(command.unseen?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
Example:

    class FunCommand < Clamp::Command
      option "--expert", :flag, "Enable expert mode.", :hidden => true

      ...
    end

The result is that the `--expert` flag is now shown via `--help`, but
it otherwise functions normally.

Fixes #46