### PR TITLE
Mutually exclusive arguments

### DIFF
--- a/lib/clamp/command.rb
+++ b/lib/clamp/command.rb
@@ -50,6 +50,7 @@ module Clamp
     def parse(arguments)
       @remaining_arguments = arguments.dup
       parse_options
+      parse_scopes
       parse_parameters
       parse_subcommand
       handle_remaining_arguments

--- a/lib/clamp/option/definition.rb
+++ b/lib/clamp/option/definition.rb
@@ -11,6 +11,7 @@ module Clamp
         @type = type
         @description = description
         super(options)
+        @scope = options[:scope]
         @multivalued = options[:multivalued]
         if options.has_key?(:required)
           @required = options[:required]
@@ -24,7 +25,7 @@ module Clamp
         end
       end
 
-      attr_reader :switches, :type
+      attr_reader :switches, :type, :scope
 
       def long_switch
         switches.find { |switch| switch =~ /^--/ }

--- a/lib/clamp/option/parsing.rb
+++ b/lib/clamp/option/parsing.rb
@@ -3,6 +3,10 @@ module Clamp
 
     module Parsing
 
+      def scope(name)
+        scopes[name]
+      end
+
       protected
 
       def parse_options
@@ -55,7 +59,23 @@ module Clamp
         end
       end
 
+      def parse_scopes
+        self.class.scopes.each do |name, scope|
+          count = scope.count do |option|
+            instance = option.of(self)
+            scopes[name] = option.attribute_name if instance.defined?
+            instance.defined?
+          end
+
+          signal_usage_error("Options #{scope.map(&:long_switch).join(', ')} are mutually exclusive") if count > 1
+        end
+      end
+
       private
+
+      def scopes
+        @scopes ||= {}
+      end
 
       def find_option(switch)
         self.class.find_option(switch) ||

--- a/spec/clamp/command_spec.rb
+++ b/spec/clamp/command_spec.rb
@@ -563,8 +563,8 @@ describe Clamp::Command do
 
   context "with scope declared" do
     before do
-      command.class.option "--either", :flag, "Either this option", scope: :scope_name
-      command.class.option "--or", :flag, "Or this option", scope: :scope_name
+      command.class.option "--either", :flag, "Either this option", :scope => :scope_name
+      command.class.option "--or", :flag, "Or this option",  :scope => :scope_name
     end
 
     context 'when used a few scoped arguments' do

--- a/spec/clamp/option/definition_spec.rb
+++ b/spec/clamp/option/definition_spec.rb
@@ -33,6 +33,19 @@ describe Clamp::Option::Definition do
 
     end
 
+    describe "#scope" do
+
+      it "defaults to nil" do
+        expect(option.scope).to be_nil
+      end
+
+      it "can be overridden" do
+        option = described_class.new("-n", "N", "iterations", :scope => :scope_name)
+        expect(option.scope).to eql :scope_name
+      end
+
+    end
+
     describe "#write_method" do
 
       it "is derived from the attribute_name" do


### PR DESCRIPTION
It works like that:

```ruby
require 'clamp'
class ScopedArgs < Clamp::Command
  scope :some_scope do
    option '--either', :flag, 'Either this option'
    option '--or', :flag, 'or this'
  end

  def execute
    puts scope(:some_scope)
  end
end

ScopedArgs.run(File.basename($0), %w{--either})
# => either
ScopedArgs.run(File.basename($0), %w{--or})
# => or
ScopedArgs.run(File.basename($0), %w{--either --or})
# => ERROR: Options --either, --or are mutually exclusive
# => 
# => See: 'pry --help'
```