### PR TITLE
Allow subcommand_class to be a proc or a hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,26 @@ class InitCommand < Clamp::Command
 end
 ```
 
+Or a Proc that will only be called when the subcommand is accessed:
+
+```ruby
+class MainCommand < Clamp::Command
+
+  subcommand "init", "Initialize the repository", proc { require 'commands/init_command'; InitCommand }
+
+end
+```
+
+Or as a hash with class name as the key and require path as the value:
+
+```ruby
+class MainCommand < Clamp::Command
+
+  subcommand "init", "Initialize the repository", "Commands::InitCommand" => File.join(__dir__, 'commands/init_command')
+
+end
+```
+
 Like options, subcommands may have aliases:
 
 ```ruby

--- a/examples/barhop
+++ b/examples/barhop
@@ -1,0 +1,36 @@
+#! /usr/bin/env ruby
+
+# An example of subcommand defined as a proc instead of a class.
+#
+# This way you can for example require your subcommand class inside the
+# proc and it will only be loaded when the subcommand is accessed.
+
+require "clamp"
+
+module Bar
+  class ListCommand < Clamp::Command
+    def execute
+      puts "All bars closed by the health inspector"
+    end
+  end
+end
+
+class BarCommand < Clamp::Command
+
+  subcommand "list", "List open bars", proc {
+    ENV["DEBUG"] && puts("Called list subcommand proc on BarCommand")
+    Bar::ListCommand
+  }
+
+  def execute
+  end
+end
+
+Clamp do
+
+  subcommand "bar", "Bar related commands", proc { BarCommand }
+
+  def execute
+  end
+end
+

--- a/examples/clubhop
+++ b/examples/clubhop
@@ -1,0 +1,15 @@
+#! /usr/bin/env ruby
+
+# An example of subcommand defined as a hash instead of a class.
+
+require "clamp"
+
+Clamp do
+
+  subcommand "bar", "Bar related commands", "Clubhopping::BarCommand" => File.join(__dir__, 'clubhopping/bar_command')
+
+  def execute
+  end
+end
+
+

--- a/examples/clubhopping/bar_command.rb
+++ b/examples/clubhopping/bar_command.rb
@@ -1,0 +1,9 @@
+module Clubhopping
+  class BarCommand < Clamp::Command
+
+    subcommand "list", "List open bars", "Clubhopping::Bar::ListCommand" => File.join(__dir__, 'list_command')
+
+    def execute
+    end
+  end
+end

--- a/examples/clubhopping/list_command.rb
+++ b/examples/clubhopping/list_command.rb
@@ -1,0 +1,9 @@
+module Clubhopping::Bar
+  class ListCommand < Clamp::Command
+    ENV["DEBUG"] && puts("Loaded ListCommand")
+
+    def execute
+      puts "All bars closed by the health inspector"
+    end
+  end
+end

--- a/lib/clamp/subcommand/definition.rb
+++ b/lib/clamp/subcommand/definition.rb
@@ -11,11 +11,21 @@ module Clamp
 
       attr_reader :names, :description
 
+      def class_from_string(string)
+        if RUBY_VERSION >= '2.0.0'
+          Object.const_get(string)
+        else
+          parts = string.split('::')
+          base = parts.shift
+          parts.inject(Object.const_get(base)) { |new_base, part| new_base.const_get(part) }
+        end
+      end
+
       def subcommand_class
         if @subcommand_definition.kind_of?(Hash)
           klass, path = @subcommand_definition.first
           require(path)
-          Object.const_get(klass)
+          class_from_string(klass)
         elsif @subcommand_definition.respond_to?(:call)
           @subcommand_definition.call
         else

--- a/lib/clamp/subcommand/definition.rb
+++ b/lib/clamp/subcommand/definition.rb
@@ -3,13 +3,25 @@ module Clamp
 
     class Definition < Struct.new(:name, :description, :subcommand_class)
 
-      def initialize(names, description, subcommand_class)
+      def initialize(names, description, subcommand_definition)
         @names = Array(names)
         @description = description
-        @subcommand_class = subcommand_class
+        @subcommand_definition = subcommand_definition
       end
 
-      attr_reader :names, :description, :subcommand_class
+      attr_reader :names, :description
+
+      def subcommand_class
+        if @subcommand_definition.kind_of?(Hash)
+          klass, path = @subcommand_definition.first
+          require(path)
+          Object.const_get(klass)
+        elsif @subcommand_definition.respond_to?(:call)
+          @subcommand_definition.call
+        else
+          @subcommand_definition
+        end
+      end
 
       def is_called?(name)
         names.member?(name)

--- a/spec/clamp/command_group_spec.rb
+++ b/spec/clamp/command_group_spec.rb
@@ -324,4 +324,48 @@ describe Clamp::Command do
 
   end
 
+  context "with a subcommand defined as a proc" do
+
+    given_command 'foo' do
+
+      class BarCommand < Clamp::Command
+        def execute
+          puts "Bar closed"
+        end
+      end
+
+      subcommand 'bar', 'Go to the bar', proc { BarCommand }
+      def execute
+      end
+    end
+
+    it "calls the proc" do
+      command.run(['bar'])
+      expect(stdout).to match /Bar closed/
+    end
+
+    it "shows the subcommand in parent's help as usual" do
+      expect(command.help).to match /Go to the bar/
+    end
+  end
+
+  context "with a subcommand defined as a hash" do
+
+    given_command 'foo' do
+
+      subcommand 'bar', 'Go to the bar', "Example::BarCommand" => File.expand_path('../subcommand/example.rb', __FILE__)
+      def execute
+      end
+    end
+
+    it "loads the file and calls the class" do
+      command.run(['bar'])
+      expect(stdout).to match /Bar closed/
+    end
+
+    it "shows the subcommand in parent's help as usual" do
+      expect(command.help).to match /Go to the bar/
+    end
+  end
+
 end

--- a/spec/clamp/subcommand/example.rb
+++ b/spec/clamp/subcommand/example.rb
@@ -1,0 +1,7 @@
+module Example
+  class BarCommand < Clamp::Command
+    def execute
+      puts "Bar closed"
+    end
+  end
+end


### PR DESCRIPTION
This PR makes it possible to define subcommand class via a proc or a hash to avoid loading all subcommands when they're not needed.

Currently it goes something like this:
```ruby
# main_command.rb

require_relative 'commands/foo_command'
class MainCommand < Clamp:Command
  subcommand 'foo', 'Foo related commands', Commands::FooCommand
  def execute
  end
end

# commands/foo_command.rb
require_relative 'foo/list_command'

module Commands
  class FooCommand < Clamp::Command
    subcommand 'list', 'List foos', Commands::FooCommand
    def execute
    end
  end
end

# commands/foo/list_command.rb
module Commands::Foo
  class ListCommand < Clamp::Command
    def execute
      puts "Foos: foo1, foo2"
    end
  end
end
```

Doing it like this will load all the subcommands when any command is executed.

With this PR it's now possible to do:

```ruby
# main_command.rb

class MainCommand < Clamp:Command
  subcommand 'foo', 'Foo related commands', proc { require 'commands/foo_command'; Commands::FooCommand }
end
```

or:

```ruby
# main_command.rb

class MainCommand < Clamp:Command
  subcommand 'foo', 'Foo related commands', "Commands::FooCommand" => File.join(__dir__, 'commands/foo_command')
  def execute
  end
end
```

And now the files are loaded only when the subcommands are accessed.
