### PR TITLE
Add :prompt to options and parameters for supplying a prompt proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,19 @@ def default_admin_port
 end
 ```
 
+### Prompted values
+
+It is possible to define a proc that prompts for the value if not given on the command line for a parameter or an option
+
+```ruby
+parameter "MESSAGE", "Message to send", prompt: proc { print "Enter message: "; gets.chomp }
+option "--name", "NAME", "Recipient name", prompt: proc { print "Enter recipient name: "; gets.chomp }
+
+def execute
+  puts "#{message}: #{name}"
+end
+```
+
 ### Environment variable support
 
 Options (and optional parameters) can also be associated with environment variables:

--- a/examples/prompt
+++ b/examples/prompt
@@ -1,0 +1,17 @@
+#! /usr/bin/env ruby
+
+# An example of prompt
+
+require "clamp"
+
+Clamp do
+
+  parameter "[MESSAGE]", "Message", prompt: proc { print "Enter message: "; gets.chomp }
+  option '--name', '[NAME]', "Name of person to send the message to", prompt: proc { print "Enter recipient: "; gets.chomp }
+
+  def execute
+    puts "#{name}: #{message}"
+  end
+
+end
+

--- a/lib/clamp/attribute/definition.rb
+++ b/lib/clamp/attribute/definition.rb
@@ -12,6 +12,9 @@ module Clamp
         if options.has_key?(:default)
           @default_value = options[:default]
         end
+        if options.has_key?(:prompt)
+          @prompt = options[:prompt]
+        end
         if options.has_key?(:environment_variable)
           @environment_variable = options[:environment_variable]
         end
@@ -20,7 +23,7 @@ module Clamp
         end
       end
 
-      attr_reader :description, :environment_variable
+      attr_reader :description, :environment_variable, :prompt
 
       def help_rhs
         description + default_description
@@ -69,7 +72,9 @@ module Clamp
       end
 
       def default_value
-        if defined?(@default_value)
+        if defined?(@prompt) && @prompt.respond_to?(:call)
+          @prompt.call(@default_value)
+        elsif defined?(@default_value)
           @default_value
         elsif multivalued?
           []
@@ -83,12 +88,16 @@ module Clamp
       private
 
       def default_description
-        default_sources = [
-          ("$#{@environment_variable}" if defined?(@environment_variable)),
-          (@default_value.inspect if defined?(@default_value))
-        ].compact
-        return "" if default_sources.empty?
-        " (default: " + default_sources.join(", or ") + ")"
+        if defined?(@prompt) && @prompt.respond_to?(:call)
+          " (default: prompt)"
+        else
+          default_sources = [
+            ("$#{@environment_variable}" if defined?(@environment_variable)),
+            (@default_value.inspect if defined?(@default_value))
+          ].compact
+          return "" if default_sources.empty?
+          " (default: " + default_sources.join(", or ") + ")"
+        end
       end
 
     end

--- a/lib/clamp/attribute/instance.rb
+++ b/lib/clamp/attribute/instance.rb
@@ -73,6 +73,16 @@ module Clamp
         end
       end
 
+      def value_from_prompt
+        return if self.defined?
+        return if attribute.prompt.nil?
+        begin
+          take(attribute.prompt.call)
+        rescue ArgumentError => e
+          command.send(:signal_usage_error, Clamp.message(:prompt_argument_error, :message => e.message))
+        end
+      end
+
     end
 
   end

--- a/lib/clamp/messages.rb
+++ b/lib/clamp/messages.rb
@@ -23,6 +23,7 @@ module Clamp
       :option_argument_error => "option '%<switch>s': %<message>s",
       :parameter_argument_error => "parameter '%<param>s': %<message>s",
       :env_argument_error => "$%<env>s: %<message>s",
+      :prompt_argument_error => "Prompt error: %<message>s",
       :unrecognised_option => "Unrecognised option '%<switch>s'",
       :no_such_subcommand => "No such sub-command '%<name>s'",
       :no_value_provided => "no value provided",

--- a/lib/clamp/option/definition.rb
+++ b/lib/clamp/option/definition.rb
@@ -22,9 +22,12 @@ module Clamp
             raise ArgumentError, "A required flag (boolean) doesn't make sense."
           end
         end
+        if options.has_key?(:prompt)
+          @prompt = options[:prompt]
+        end
       end
 
-      attr_reader :switches, :type
+      attr_reader :switches, :type, :prompt
 
       def long_switch
         switches.find { |switch| switch =~ /^--/ }

--- a/lib/clamp/option/parsing.rb
+++ b/lib/clamp/option/parsing.rb
@@ -36,9 +36,10 @@ module Clamp
 
         end
 
-        # Fill in gap from environment
+        # Fill in gap from environment or prompt
         self.class.recognised_options.each do |option|
           option.of(self).default_from_environment
+          option.of(self).value_from_prompt
         end
 
         # Verify that all required options are present

--- a/lib/clamp/parameter/definition.rb
+++ b/lib/clamp/parameter/definition.rb
@@ -13,16 +13,20 @@ module Clamp
         @required = options.fetch(:required) do
           (@name !~ OPTIONAL)
         end
+        @prompt = options[:prompt]
       end
 
-      attr_reader :name
+      attr_reader :name, :prompt
 
       def help_lhs
         name
       end
 
       def consume(arguments)
-        raise ArgumentError, Clamp.message(:no_value_provided) if required? && arguments.empty?
+        if arguments.empty?
+          return Array(prompt.call) if prompt
+          raise ArgumentError, Clamp.message(:no_value_provided) if required?
+        end
         arguments.shift(multivalued? ? arguments.length : 1)
       end
 

--- a/lib/clamp/parameter/parsing.rb
+++ b/lib/clamp/parameter/parsing.rb
@@ -19,6 +19,7 @@ module Clamp
 
         self.class.parameters.each do |parameter|
           parameter.of(self).default_from_environment
+          parameter.of(self).value_from_prompt
         end
 
       end

--- a/spec/clamp/option/definition_spec.rb
+++ b/spec/clamp/option/definition_spec.rb
@@ -178,6 +178,16 @@ describe Clamp::Option::Definition do
 
   end
 
+  context "with prompt" do
+    let(:option) do
+      described_class.new("--name", ['NAME'], "Name", prompt: proc { "foobar" } )
+    end
+
+    it "runs the proc in prompt" do
+      expect(option.default_value).to match /foobar/
+    end
+  end
+
   context "multivalued" do
 
     let(:option) do

--- a/spec/clamp/parameter/definition_spec.rb
+++ b/spec/clamp/parameter/definition_spec.rb
@@ -246,7 +246,7 @@ describe Clamp::Parameter::Definition do
     end
 
     it "runs the proc in prompt" do
-      expect(parameter.consume("")).to match /prompted name/
+      expect(parameter.consume("").first).to match /prompted name/
     end
 
   end

--- a/spec/clamp/parameter/definition_spec.rb
+++ b/spec/clamp/parameter/definition_spec.rb
@@ -239,4 +239,16 @@ describe Clamp::Parameter::Definition do
 
   end
 
+  context "with prompt" do
+
+    let(:parameter) do
+      described_class.new("[NAME]", "Name to print", prompt: proc { "prompted name" })
+    end
+
+    it "runs the proc in prompt" do
+      expect(parameter.consume("")).to match /prompted name/
+    end
+
+  end
+
 end


### PR DESCRIPTION
Another way to get values for options and param, supply a proc in :prompt option.

```ruby
Clamp do

  parameter "[MESSAGE]", "Message", prompt: proc { print "Enter message: "; gets.chomp }
  option '--name', '[NAME]', "Name of person to send the message to", prompt: proc { print "Enter recipient: "; gets.chomp }

  def execute
    puts "#{name}: #{message}"
  end

end
```
