### PR TITLE
Try command_class.subcommand_missing before signaling error

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,19 @@ Options are inheritable, so any options declared for a command are supported by 
 
 Note that, if a subcommand accepts options, they must be specified on the command-line _after_ the subcommand name.
 
+You can define a `subcommand_missing` method that is called when user tries to run an unknown subcommand:
+
+```ruby
+Clamp do
+  def subcommand_missing(name)
+    if name == "foo"
+      return Object.const_get(:FooPlugin) if Object.const_defined?(:FooPlugin)
+      abort "Subcommand 'foo' requires plugin X"
+    end
+  end
+end
+```
+
 Getting help
 ------------
 

--- a/examples/subcommand_missing
+++ b/examples/subcommand_missing
@@ -1,0 +1,22 @@
+#! /usr/bin/env ruby
+
+require 'clamp'
+
+Clamp do
+  subcommand 'hello', 'Say hello' do
+    def execute
+      puts "Hello"
+    end
+  end
+
+  def subcommand_missing(name)
+    if name == 'bye'
+      abort "Install bye plugin first"
+    end
+  end
+
+  def execute
+    puts "Why we need this?"
+  end
+
+end

--- a/examples/subcommand_missing
+++ b/examples/subcommand_missing
@@ -13,6 +13,7 @@ Clamp do
     if name == 'bye'
       abort "Install bye plugin first"
     end
+    super
   end
 
   def execute

--- a/lib/clamp/command.rb
+++ b/lib/clamp/command.rb
@@ -82,6 +82,13 @@ module Clamp
       self.class.help(invocation_path)
     end
 
+    # Abort with subcommand missing usage error
+    #
+    # @ param [String] name subcommand_name
+    def subcommand_missing(name)
+      signal_usage_error(Clamp.message(:no_such_subcommand, :name => name))
+    end
+
     include Clamp::Option::Parsing
     include Clamp::Parameter::Parsing
     include Clamp::Subcommand::Parsing

--- a/lib/clamp/subcommand/execution.rb
+++ b/lib/clamp/subcommand/execution.rb
@@ -25,7 +25,11 @@ module Clamp
       end
 
       def find_subcommand_class(name)
-        subcommand_def = self.class.find_subcommand(name) || signal_usage_error(Clamp.message(:no_such_subcommand, :name => name))
+        subcommand_def = self.class.find_subcommand(name)
+        unless subcommand_def
+          subcommand_def = subcommand_missing(name) if self.respond_to?(:subcommand_missing)
+          signal_usage_error(Clamp.message(:no_such_subcommand, :name => name)) unless subcommand_def
+        end
         subcommand_def.subcommand_class
       end
 

--- a/lib/clamp/subcommand/execution.rb
+++ b/lib/clamp/subcommand/execution.rb
@@ -25,11 +25,7 @@ module Clamp
       end
 
       def find_subcommand_class(name)
-        subcommand_def = self.class.find_subcommand(name)
-        unless subcommand_def
-          subcommand_def = subcommand_missing(name) if self.respond_to?(:subcommand_missing)
-          signal_usage_error(Clamp.message(:no_such_subcommand, :name => name)) unless subcommand_def
-        end
+        subcommand_def = self.class.find_subcommand(name) || self.subcommand_missing(name)
         subcommand_def.subcommand_class
       end
 

--- a/lib/clamp/subcommand/execution.rb
+++ b/lib/clamp/subcommand/execution.rb
@@ -25,8 +25,9 @@ module Clamp
       end
 
       def find_subcommand_class(name)
-        subcommand_def = self.class.find_subcommand(name) || self.subcommand_missing(name)
-        subcommand_def.subcommand_class
+        subcommand_def = self.class.find_subcommand(name)
+        return subcommand_def.subcommand_class if subcommand_def
+        subcommand_missing(name)
       end
 
     end

--- a/spec/clamp/command_group_spec.rb
+++ b/spec/clamp/command_group_spec.rb
@@ -324,4 +324,45 @@ describe Clamp::Command do
 
   end
 
+  context "with an unknown subcommand" do
+
+    let(:subcommand_missing) do
+      Module.new do
+        def subcommand_missing(name)
+          abort "there is no such thing"
+        end
+      end
+    end
+
+    let(:command_class) do
+
+      Class.new(Clamp::Command) do
+        subcommand "test", "test subcommand" do
+          def execute
+            puts "known subcommand"
+          end
+        end
+
+        def execute
+        end
+      end
+    end
+
+    let(:command) do
+      command_class.new("foo")
+    end
+
+    it "should signal no such subcommand usage error" do
+      expect{command.run(['foo'])}.to raise_error(Clamp::UsageError) do |exception|
+        expect(exception.message).to eq "No such sub-command 'foo'"
+      end
+    end
+
+    it "should execute the subcommand missing method" do
+      command.extend subcommand_missing
+      expect{command.run(['foo'])}.to raise_error(SystemExit)
+      expect(stderr).to match /there is no such thing/
+    end
+  end
+
 end

--- a/spec/clamp/command_group_spec.rb
+++ b/spec/clamp/command_group_spec.rb
@@ -337,7 +337,7 @@ describe Clamp::Command do
     let(:subcommand_missing_with_return) do
       Module.new do
         def subcommand_missing(name)
-          self.class.recognised_subcommands.first
+          self.class.recognised_subcommands.first.subcommand_class
         end
       end
     end

--- a/spec/clamp/command_group_spec.rb
+++ b/spec/clamp/command_group_spec.rb
@@ -334,6 +334,14 @@ describe Clamp::Command do
       end
     end
 
+    let(:subcommand_missing_with_return) do
+      Module.new do
+        def subcommand_missing(name)
+          self.class.recognised_subcommands.first
+        end
+      end
+    end
+
     let(:command_class) do
 
       Class.new(Clamp::Command) do
@@ -362,6 +370,12 @@ describe Clamp::Command do
       command.extend subcommand_missing
       expect{command.run(['foo'])}.to raise_error(SystemExit)
       expect(stderr).to match /there is no such thing/
+    end
+
+    it "should use the subcommand class returned from subcommand_missing" do
+      command.extend subcommand_missing_with_return
+      command.run(['foo'])
+      expect(stdout).to match /known subcommand/
     end
   end
 


### PR DESCRIPTION
```ruby
Clamp do
  def subcommand_missing(name)
    if name == "foo"
      return Object.const_get(:FooPlugin) if Object.const_defined?(:FooPlugin)
      abort "Subcommand 'foo' requires plugin X"
    end
  end
end
```