### PR TITLE
Alias define_accessors_for for compatibility with 1.0.0

### DIFF
--- a/lib/clamp/attribute/declaration.rb
+++ b/lib/clamp/attribute/declaration.rb
@@ -15,6 +15,7 @@ module Clamp
           define_simple_writer_for(attribute, &block)
         end
       end
+      alias_method :define_accessors_for, :declare_attribute
 
       private
 


### PR DESCRIPTION
Allows clamp apps using their own OptionDefinition subclasses to remain
compatible with 1.0.0 and newer, as the method was renamed in 3d3788a.