### PR TITLE
Allow options after or between parameters

### DIFF
--- a/lib/clamp/option/parsing.rb
+++ b/lib/clamp/option/parsing.rb
@@ -52,6 +52,8 @@ module Clamp
             signal_usage_error Clamp.message(:option_argument_error, :switch => switch, :message => e.message)
           end
         end
+
+        remaining_arguments.replace(remaining_params + after_break_params)
       end
 
       def default_options_from_environment
@@ -74,8 +76,6 @@ module Clamp
           end
           signal_usage_error message
         end
-
-        remaining_arguments.replace(remaining_params + after_break_params)
       end
 
       def find_option(switch)

--- a/spec/clamp/command_spec.rb
+++ b/spec/clamp/command_spec.rb
@@ -379,11 +379,12 @@ describe Clamp::Command do
 
       end
 
-      context "with option-like things beyond the arguments" do
+      context "with options after parameters" do
 
-        it "treats them as positional arguments" do
-          command.parse(%w(a b c --flavour strawberry))
-          expect(command.arguments).to eql %w(a b c --flavour strawberry)
+        it "treats them as options" do
+          command.parse(%w(a b --flavour strawberry c))
+          expect(command.arguments).to eql %w(a b c)
+          expect(command.flavour).to eql "strawberry"
         end
 
       end


### PR DESCRIPTION
Fixes #71

Allows random option / parameter order, such as:
`--<FLAG> <PARAM> --<OPTION> <VALUE> <PARAM> --<FLAG>`

And most importantly, something like this works:

`$ command subcommand parameter --help`
or
`$ command subcommand parameter --force`

Without having to clear out the parameter or move the cursor before parameters.
