### PR TITLE
Optionally allow options and parameters to be interspersed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## PENDING
+
+* Add option to `Clamp.allow_options_after_parameters`.
+
 ## 1.1.2 (2017-02-12)
 
 * Improve usage help for commands with both parameters and subcommands.

--- a/README.md
+++ b/README.md
@@ -296,6 +296,18 @@ parameter "[HOST]", "server address", :environment_variable => "MYAPP_HOST"
 
 Clamp will check the specified envariables in the absence of values supplied on the command line, before looking for a default value.
 
+### Allowing options after parameters
+
+Many option-parsing libraries - notably [GNU `getopt(3)`](https://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html) - allow option and parameter arguments to appear in any order on the command-line, e.g.
+
+    foobar --foo=bar something --fnord=snuffle another-thing
+
+By default, Clamp does not allow options and parameters to be "interspersed" in this way. If you want that behaviour, set:
+
+```ruby
+Clamp.allow_options_after_parameters = true
+```
+
 Declaring Subcommands
 ---------------------
 

--- a/README.md
+++ b/README.md
@@ -298,11 +298,13 @@ Clamp will check the specified envariables in the absence of values supplied on 
 
 ### Allowing options after parameters
 
-Many option-parsing libraries - notably [GNU `getopt(3)`](https://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html) - allow option and parameter arguments to appear in any order on the command-line, e.g.
+By default, Clamp only recognises options _before_ positional parameters. 
+
+Some other option-parsing libraries - notably [GNU `getopt(3)`](https://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html) - allow option and parameter arguments to appear in any order on the command-line, e.g.
 
     foobar --foo=bar something --fnord=snuffle another-thing
 
-By default, Clamp does not allow options and parameters to be "interspersed" in this way. If you want that behaviour, set:
+If you want Clamp to allow options and parameters to be "interspersed" in this way, set:
 
 ```ruby
 Clamp.allow_options_after_parameters = true

--- a/lib/clamp/option/parsing.rb
+++ b/lib/clamp/option/parsing.rb
@@ -19,12 +19,13 @@ module Clamp
       private
 
       def set_options_from_command_line
-        buffered_arguments = []
+        argument_buffer = []
+        argument_buffer_limit = self.class.parameter_buffer_limit
         until remaining_arguments.empty?
 
           unless remaining_arguments.first.start_with?("-")
-            if Clamp.allow_options_after_parameters
-              buffered_arguments << remaining_arguments.shift
+            if argument_buffer.size < argument_buffer_limit
+              argument_buffer << remaining_arguments.shift
               next
             else
               break
@@ -57,7 +58,7 @@ module Clamp
           end
 
         end
-        remaining_arguments.unshift(*buffered_arguments)
+        remaining_arguments.unshift(*argument_buffer)
       end
 
       def default_options_from_environment

--- a/lib/clamp/option/parsing.rb
+++ b/lib/clamp/option/parsing.rb
@@ -1,4 +1,9 @@
 module Clamp
+
+  class << self
+    attr_accessor :allow_options_after_parameters
+  end
+
   module Option
 
     module Parsing
@@ -14,7 +19,17 @@ module Clamp
       private
 
       def set_options_from_command_line
-        while remaining_arguments.first && remaining_arguments.first.start_with?("-")
+        buffered_arguments = []
+        until remaining_arguments.empty?
+
+          unless remaining_arguments.first.start_with?("-")
+            if Clamp.allow_options_after_parameters
+              buffered_arguments << remaining_arguments.shift
+              next
+            else
+              break
+            end
+          end
 
           switch = remaining_arguments.shift
           break if switch == "--"
@@ -42,6 +57,7 @@ module Clamp
           end
 
         end
+        remaining_arguments.unshift(*buffered_arguments)
       end
 
       def default_options_from_environment
@@ -74,4 +90,5 @@ module Clamp
     end
 
   end
+
 end

--- a/lib/clamp/parameter/declaration.rb
+++ b/lib/clamp/parameter/declaration.rb
@@ -27,6 +27,12 @@ module Clamp
         superclass_inheritable_parameters + parameters.select(&:inheritable?)
       end
 
+      def parameter_buffer_limit
+        return 0 unless Clamp.allow_options_after_parameters
+        return Float::INFINITY if inheritable_parameters.any?(&:multivalued?)
+        inheritable_parameters.size
+      end
+
       private
 
       def superclass_inheritable_parameters

--- a/lib/clamp/version.rb
+++ b/lib/clamp/version.rb
@@ -1,3 +1,3 @@
 module Clamp
-  VERSION = "1.1.2".freeze
+  VERSION = "1.2.0.beta1".freeze
 end

--- a/spec/clamp/command_spec.rb
+++ b/spec/clamp/command_spec.rb
@@ -387,24 +387,6 @@ describe Clamp::Command do
           expect(command.arguments).to eql %w(a b c --flavour strawberry)
         end
 
-        context "when such things are explicitly allowed" do
-
-          before do
-            Clamp.allow_options_after_parameters = true
-          end
-
-          it "treats them as option arguments" do
-            command.parse(%w(a b --flavour strawberry c))
-            expect(command.flavour).to eql "strawberry"
-            expect(command.arguments).to eql %w(a b c)
-          end
-
-          after do
-            Clamp.allow_options_after_parameters = false
-          end
-
-        end
-
       end
 
       context "with multi-line arguments that look like options" do

--- a/spec/clamp/command_spec.rb
+++ b/spec/clamp/command_spec.rb
@@ -387,6 +387,24 @@ describe Clamp::Command do
           expect(command.arguments).to eql %w(a b c --flavour strawberry)
         end
 
+        context "when such things are explicitly allowed" do
+
+          before do
+            Clamp.allow_options_after_parameters = true
+          end
+
+          it "treats them as option arguments" do
+            command.parse(%w(a b --flavour strawberry c))
+            expect(command.flavour).to eql "strawberry"
+            expect(command.arguments).to eql %w(a b c)
+          end
+
+          after do
+            Clamp.allow_options_after_parameters = false
+          end
+
+        end
+
       end
 
       context "with multi-line arguments that look like options" do

--- a/spec/clamp/option_reordering_spec.rb
+++ b/spec/clamp/option_reordering_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+describe Clamp::Command do
+
+  extend CommandFactory
+  include OutputCapture
+
+  context "with allow_options_after_parameters enabled" do
+
+    before do
+      Clamp.allow_options_after_parameters = true
+    end
+
+    after do
+      Clamp.allow_options_after_parameters = false
+    end
+
+    given_command("cmd") do
+
+      option ["-v", "--verbose"], :flag, "Be noisy"
+
+      subcommand "say", "Say something" do
+
+        option "--loud", :flag, "say it loud"
+
+        parameter "WORDS ...", "the thing to say", :attribute_name => :words
+
+        def execute
+          message = words.join(" ")
+          message = message.upcase if loud?
+          message *= 3 if verbose?
+          $stdout.puts message
+        end
+
+      end
+
+    end
+
+    it "still works" do
+      command.class.run("cmd", %w(say foo))
+      expect(stdout).to eql("foo\n")
+    end
+
+    it "honours options after positional arguments" do
+      command_class.run("cmd", %w(say blah --verbose))
+      expect(stdout).to eql("blahblahblah\n")
+    end
+
+  end
+
+end

--- a/spec/clamp/option_reordering_spec.rb
+++ b/spec/clamp/option_reordering_spec.rb
@@ -37,13 +37,18 @@ describe Clamp::Command do
     end
 
     it "still works" do
-      command.class.run("cmd", %w(say foo))
+      command.run(%w(say foo))
       expect(stdout).to eql("foo\n")
     end
 
     it "honours options after positional arguments" do
-      command_class.run("cmd", %w(say blah --verbose))
+      command.run(%w(say blah --verbose))
       expect(stdout).to eql("blahblahblah\n")
+    end
+
+    it "honours options declared on subcommands" do
+      command.run(%w(say --loud blah))
+      expect(stdout).to eql("BLAH\n")
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,14 @@ RSpec.configure do |config|
 
   config.mock_with :rr
 
+  config.around(:each) do |example|
+    begin
+      example.run
+    rescue SystemExit => e
+      fail "Unexpected exit with status #{e.status}"
+    end
+  end
+
 end
 
 module OutputCapture


### PR DESCRIPTION
Implements #71. 

Set `Clamp.allow_options_after_parameters = true` to enable.

What do you think, @kke?
