### PR TITLE
Use modern hash syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@ source "http://rubygems.org"
 gemspec
 
 group :development do
-  gem "guard-rspec", "~> 4.6.5", :require => false
+  gem "guard-rspec", "~> 4.6.5", require: false
   gem "listen", "~> 3.0.2"
   gem "rake", "~> 10.4"
-  gem "rubocop", "~> 0.43.0", :require => false
+  gem "rubocop", "~> 0.43.0", require: false
 end
 
 group :test do

--- a/Guardfile
+++ b/Guardfile
@@ -24,7 +24,7 @@
 #  * zeus: 'zeus rspec' (requires the server to be started separately)
 #  * 'just' rspec: 'rspec'
 
-guard :rspec, :cmd => "bundle exec rspec" do
+guard :rspec, cmd: "bundle exec rspec" do
   require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ require 'clamp'
 Clamp do
 
   option "--loud", :flag, "say it loud"
-  option ["-n", "--iterations"], "N", "say it N times", :default => 1 do |s|
+  option ["-n", "--iterations"], "N", "say it N times", default: 1 do |s|
     Integer(s)
   end
 
-  parameter "WORDS ...", "the thing to say", :attribute_name => :words
+  parameter "WORDS ...", "the thing to say", attribute_name: :words
 
   def execute
     the_truth = words.join(" ")
@@ -54,11 +54,11 @@ require 'clamp'
 class SpeakCommand < Clamp::Command
 
   option "--loud", :flag, "say it loud"
-  option ["-n", "--iterations"], "N", "say it N times", :default => 1 do |s|
+  option ["-n", "--iterations"], "N", "say it N times", default: 1 do |s|
     Integer(s)
   end
 
-  parameter "WORDS ...", "the thing to say", :attribute_name => :words
+  parameter "WORDS ...", "the thing to say", attribute_name: :words
 
   def execute
     the_truth = words.join(" ")
@@ -105,7 +105,7 @@ end
 If you don't like the inferred attribute name, you can override it:
 
 ```ruby
-option "--type", "TYPE", "type of widget", :attribute_name => :widget_type
+option "--type", "TYPE", "type of widget", attribute_name: :widget_type
                                            # to avoid clobbering Object#type
 ```
 
@@ -140,7 +140,7 @@ Clamp will handle both "`--force`" and "`--no-force`" options, setting the value
 Although "required option" is an oxymoron, Clamp lets you mark an option as required, and will verify that a value is provided:
 
 ```ruby
-option "--password", "PASSWORD", "the secret password", :required => true
+option "--password", "PASSWORD", "the secret password", required: true
 ```
 
 Note that it makes no sense to mark a `:flag` option, or one with a `:default`, as `:required`.
@@ -150,7 +150,7 @@ Note that it makes no sense to mark a `:flag` option, or one with a `:default`, 
 Declaring an option "`:multivalued`" allows it to be specified multiple times on the command line.
 
 ```ruby
-option "--format", "FORMAT", "output format", :multivalued => true
+option "--format", "FORMAT", "output format", multivalued: true
 ```
 
 The underlying attribute becomes an Array, and the suffix "`_list`" is appended to the default attribute name.  In this case, an attribute called "`format_list`" would be generated (unless you override the default by specifying an `:attribute_name`).
@@ -160,7 +160,7 @@ The underlying attribute becomes an Array, and the suffix "`_list`" is appended 
 Declaring an option "`:hidden`" will cause it to be hidden from `--help` output.
 
 ```ruby
-option "--some-option", "VALUE", "Just a little option", :hidden => true
+option "--some-option", "VALUE", "Just a little option", hidden: true
 ```
 
 ### Version option
@@ -203,7 +203,7 @@ parameter "[TARGET_DIR]", "target directory"
 Three dots at the end of a parameter name makes it "greedy" - it will consume all remaining command-line arguments.  For example:
 
 ```ruby
-parameter "FILE ...", "input files", :attribute_name => :files
+parameter "FILE ...", "input files", attribute_name: :files
 ```
 
 Like multivalued options, greedy parameters are backed by an Array attribute (named with a "`_list`" suffix, by default).
@@ -265,15 +265,15 @@ end
 Default values can be specified for options, and optional parameters:
 
 ```ruby
-option "--flavour", "FLAVOUR", "ice-cream flavour", :default => "chocolate"
+option "--flavour", "FLAVOUR", "ice-cream flavour", default: "chocolate"
 
-parameter "[HOST]", "server host", :default => "localhost"
+parameter "[HOST]", "server host", default: "localhost"
 ```
 
 For more advanced cases, you can also specify default values by defining a method called "`default_#{attribute_name}`":
 
 ```ruby
-option "--http-port", "PORT", "web-server port", :default => 9000
+option "--http-port", "PORT", "web-server port", default:  9000
 
 option "--admin-port", "PORT", "admin port"
 
@@ -287,11 +287,11 @@ end
 Options (and optional parameters) can also be associated with environment variables:
 
 ```ruby
-option "--port", "PORT", "the port to listen on", :environment_variable => "MYAPP_PORT" do |val|
+option "--port", "PORT", "the port to listen on", environment_variable: "MYAPP_PORT" do |val|
   val.to_i
 end
 
-parameter "[HOST]", "server address", :environment_variable => "MYAPP_HOST"
+parameter "[HOST]", "server address", environment_variable: "MYAPP_HOST"
 ```
 
 Clamp will check the specified envariables in the absence of values supplied on the command line, before looking for a default value.
@@ -417,10 +417,10 @@ Example usage:
 require 'gettext'
 
 Clamp.messages = {
-  :too_many_arguments =>       _("too many arguments"),
-  :option_required =>          _("option '%<option>s' is required"),
-  :option_or_env_required =>   _("option '%<option>s' (or env %<env>s) is required"),
-  :option_argument_error =>    _("option '%<switch>s': %<message>s")
+  too_many_arguments:        _("too many arguments"),
+  option_required:           _("option '%<option>s' is required"),
+  option_or_env_required:    _("option '%<option>s' (or env %<env>s) is required"),
+  option_argument_error:     _("option '%<switch>s': %<message>s")
   # ...
 }
 ```

--- a/examples/admin
+++ b/examples/admin
@@ -6,12 +6,12 @@ require "clamp"
 
 Clamp do
 
-  option "--timeout", "SECONDS", "connection timeout", :default => 5, :environment_variable => "MYAPP_TIMEOUT" do |x|
+  option "--timeout", "SECONDS", "connection timeout", default: 5, environment_variable: "MYAPP_TIMEOUT" do |x|
     Integer(x)
   end
 
   parameter "HOST", "server address"
-  parameter "[PORT]", "server port", :default => 80, :environment_variable => "MYAPP_PORT"
+  parameter "[PORT]", "server port", default: 80, environment_variable: "MYAPP_PORT"
 
   def execute
     puts "trying to connect to #{host} on port #{port} (waiting up to #{timeout} seconds)"

--- a/examples/defaulted
+++ b/examples/defaulted
@@ -8,10 +8,10 @@ require "highline"
 Clamp do
 
   option ["-U", "--user"], "USER", "user name",
-         :environment_variable => "THE_USER",
-         :default => "bob"
+         environment_variable: "THE_USER",
+         default: "bob"
   option ["-P", "--password"], "PASSWORD", "password",
-         :environment_variable => "THE_PASSWORD"
+         environment_variable: "THE_PASSWORD"
 
   def execute
     puts "User: #{user}, Password: #{password}"

--- a/examples/gitdown
+++ b/examples/gitdown
@@ -25,7 +25,7 @@ module GitDown
   class CloneCommand < AbstractCommand
 
     parameter "REPOSITORY", "repository to clone"
-    parameter "[DIR]", "working directory", :default => "."
+    parameter "[DIR]", "working directory", default: "."
 
     def execute
       say "cloning to #{dir}"

--- a/examples/scoop
+++ b/examples/scoop
@@ -7,8 +7,8 @@ require "clamp"
 Clamp do
 
   option ["-f", "--flavour"], "FLAVOUR", "flavour",
-         :multivalued => true, :default => ["chocolate"],
-         :attribute_name => :flavours
+         multivalued: true, default: ["chocolate"],
+         attribute_name: :flavours
 
   def execute
     puts "one #{flavours.join(' and ')} ice-cream"

--- a/examples/speak
+++ b/examples/speak
@@ -11,11 +11,11 @@ Clamp do
   )
 
   option "--loud", :flag, "say it loud"
-  option ["-n", "--iterations"], "N", "say it N times", :default => 1 do |s|
+  option ["-n", "--iterations"], "N", "say it N times", default: 1 do |s|
     Integer(s)
   end
 
-  parameter "WORDS ...", "the thing to say", :attribute_name => :words
+  parameter "WORDS ...", "the thing to say", attribute_name: :words
 
   def execute
     the_truth = words.join(" ")

--- a/lib/clamp/attribute/instance.rb
+++ b/lib/clamp/attribute/instance.rb
@@ -69,7 +69,7 @@ module Clamp
         begin
           take(value)
         rescue ArgumentError => e
-          command.send(:signal_usage_error, Clamp.message(:env_argument_error, :env => attribute.environment_variable, :message => e.message))
+          command.send(:signal_usage_error, Clamp.message(:env_argument_error, env: attribute.environment_variable, message: e.message))
         end
       end
 

--- a/lib/clamp/command.rb
+++ b/lib/clamp/command.rb
@@ -81,7 +81,7 @@ module Clamp
     #
     # @ param [String] name subcommand_name
     def subcommand_missing(name)
-      signal_usage_error(Clamp.message(:no_such_subcommand, :name => name))
+      signal_usage_error(Clamp.message(:no_such_subcommand, name: name))
     end
 
     include Clamp::Option::Parsing

--- a/lib/clamp/messages.rb
+++ b/lib/clamp/messages.rb
@@ -17,19 +17,19 @@ module Clamp
     private
 
     DEFAULTS = {
-      :too_many_arguments => "too many arguments",
-      :option_required => "option '%<option>s' is required",
-      :option_or_env_required => "option '%<option>s' (or env %<env>s) is required",
-      :option_argument_error => "option '%<switch>s': %<message>s",
-      :parameter_argument_error => "parameter '%<param>s': %<message>s",
-      :env_argument_error => "$%<env>s: %<message>s",
-      :unrecognised_option => "Unrecognised option '%<switch>s'",
-      :no_such_subcommand => "No such sub-command '%<name>s'",
-      :no_value_provided => "no value provided",
-      :usage_heading => "Usage",
-      :parameters_heading => "Parameters",
-      :subcommands_heading => "Subcommands",
-      :options_heading => "Options"
+      too_many_arguments: "too many arguments",
+      option_required: "option '%<option>s' is required",
+      option_or_env_required: "option '%<option>s' (or env %<env>s) is required",
+      option_argument_error: "option '%<switch>s': %<message>s",
+      parameter_argument_error: "parameter '%<param>s': %<message>s",
+      env_argument_error: "$%<env>s: %<message>s",
+      unrecognised_option: "Unrecognised option '%<switch>s'",
+      no_such_subcommand: "No such sub-command '%<name>s'",
+      no_value_provided: "no value provided",
+      usage_heading: "Usage",
+      parameters_heading: "Parameters",
+      subcommands_heading: "Subcommands",
+      options_heading: "Options"
     }.freeze
 
     def messages

--- a/lib/clamp/option/parsing.rb
+++ b/lib/clamp/option/parsing.rb
@@ -38,7 +38,7 @@ module Clamp
           begin
             option.of(self).take(value)
           rescue ArgumentError => e
-            signal_usage_error Clamp.message(:option_argument_error, :switch => switch, :message => e.message)
+            signal_usage_error Clamp.message(:option_argument_error, switch: switch, message: e.message)
           end
 
         end
@@ -56,11 +56,11 @@ module Clamp
           next unless option.required? && send(option.attribute_name).nil?
           if option.environment_variable
             message = Clamp.message(:option_or_env_required,
-                                    :option => option.switches.first,
-                                    :env => option.environment_variable)
+                                    option: option.switches.first,
+                                    env: option.environment_variable)
           else
             message = Clamp.message(:option_required,
-                                    :option => option.switches.first)
+                                    option: option.switches.first)
           end
           signal_usage_error message
         end
@@ -68,7 +68,7 @@ module Clamp
 
       def find_option(switch)
         self.class.find_option(switch) ||
-          signal_usage_error(Clamp.message(:unrecognised_option, :switch => switch))
+          signal_usage_error(Clamp.message(:unrecognised_option, switch: switch))
       end
 
     end

--- a/lib/clamp/parameter/parsing.rb
+++ b/lib/clamp/parameter/parsing.rb
@@ -19,7 +19,7 @@ module Clamp
               parameter.of(self).take(value)
             end
           rescue ArgumentError => e
-            signal_usage_error Clamp.message(:parameter_argument_error, :param => parameter.name, :message => e.message)
+            signal_usage_error Clamp.message(:parameter_argument_error, param: parameter.name, message: e.message)
           end
         end
       end

--- a/lib/clamp/subcommand/declaration.rb
+++ b/lib/clamp/subcommand/declaration.rb
@@ -59,19 +59,19 @@ module Clamp
       def declare_subcommand_parameters
         if @default_subcommand
           parameter "[SUBCOMMAND]", "subcommand",
-                    :attribute_name => :subcommand_name,
-                    :default => @default_subcommand,
-                    :inheritable => false
+                    attribute_name: :subcommand_name,
+                    default: @default_subcommand,
+                    inheritable: false
         else
           parameter "SUBCOMMAND", "subcommand",
-                    :attribute_name => :subcommand_name,
-                    :required => false,
-                    :inheritable => false
+                    attribute_name: :subcommand_name,
+                    required: false,
+                    inheritable: false
         end
         remove_method :default_subcommand_name
         parameter "[ARG] ...", "subcommand arguments",
-                  :attribute_name => :subcommand_arguments,
-                  :inheritable => false
+                  attribute_name: :subcommand_arguments,
+                  inheritable: false
       end
 
     end

--- a/spec/clamp/command_group_spec.rb
+++ b/spec/clamp/command_group_spec.rb
@@ -274,12 +274,12 @@ describe Clamp::Command do
 
       speed_options = Module.new do
         extend Clamp::Option::Declaration
-        option "--speed", "SPEED", "how fast", :default => "slowly"
+        option "--speed", "SPEED", "how fast", default: "slowly"
       end
 
       Class.new(Clamp::Command) do
 
-        option "--direction", "DIR", "which way", :default => "home"
+        option "--direction", "DIR", "which way", default: "home"
 
         include speed_options
 
@@ -315,7 +315,7 @@ describe Clamp::Command do
     end
 
     it "has access to command context" do
-      command = command_class.new("go", :motion => "wandering")
+      command = command_class.new("go", motion: "wandering")
       command.run(["move"])
       expect(stdout).to match(/wandering home/)
     end

--- a/spec/clamp/command_spec.rb
+++ b/spec/clamp/command_spec.rb
@@ -60,7 +60,7 @@ describe Clamp::Command do
     context "with explicit :attribute_name" do
 
       before do
-        command.class.option "--foo", "FOO", "A foo", :attribute_name => :bar
+        command.class.option "--foo", "FOO", "A foo", attribute_name: :bar
       end
 
       it "uses the specified attribute_name name to name accessors" do
@@ -95,7 +95,7 @@ describe Clamp::Command do
     context "with :default value" do
 
       before do
-        command.class.option "--port", "PORT", "port to listen on", :default => 4321
+        command.class.option "--port", "PORT", "port to listen on", default: 4321
       end
 
       it "declares default method" do
@@ -115,7 +115,7 @@ describe Clamp::Command do
     context "with :multivalued" do
 
       before do
-        command.class.option "--flavour", "FLAVOUR", "flavour(s)", :multivalued => true, :attribute_name => :flavours
+        command.class.option "--flavour", "FLAVOUR", "flavour(s)", multivalued: true, attribute_name: :flavours
       end
 
       it "defaults to empty array" do
@@ -148,8 +148,8 @@ describe Clamp::Command do
 
       before do
         command.class.option "--port", "PORT", "port to listen on",
-                             :default => 4321,
-                             :environment_variable => "PORT",
+                             default: 4321,
+                             environment_variable: "PORT",
                              &:to_i
         set_env("PORT", environment_value)
         command.parse(args)
@@ -198,7 +198,7 @@ describe Clamp::Command do
       let(:environment_value) { nil }
 
       before do
-        command.class.option "--[no-]enable", :flag, "enable?", :default => false, :environment_variable => "ENABLE"
+        command.class.option "--[no-]enable", :flag, "enable?", default: false, environment_variable: "ENABLE"
         set_env("ENABLE", environment_value)
         command.parse([])
       end
@@ -244,7 +244,7 @@ describe Clamp::Command do
     context "with :required" do
 
       before do
-        command.class.option "--port", "PORT", "port to listen on", :required => true
+        command.class.option "--port", "PORT", "port to listen on", required: true
       end
 
       context "when no value is provided" do
@@ -295,12 +295,12 @@ describe Clamp::Command do
       command.class.option ["-f", "--flavour"], "FLAVOUR", "Flavour of the month"
       command.class.option ["-c", "--color"], "COLOR", "Preferred hue"
       command.class.option ["--scoops"], "N", "Number of scoops",
-                           :default => 1,
-                           :environment_variable => "DEFAULT_SCOOPS" do |arg|
+                           default: 1,
+                           environment_variable: "DEFAULT_SCOOPS" do |arg|
         Integer(arg)
       end
       command.class.option ["-n", "--[no-]nuts"], :flag, "Nuts (or not)\nMay include nuts"
-      command.class.parameter "[ARG] ...", "extra arguments", :attribute_name => :arguments
+      command.class.parameter "[ARG] ...", "extra arguments", attribute_name: :arguments
     end
 
     describe "#parse" do
@@ -552,7 +552,7 @@ describe Clamp::Command do
     context "with explicit :attribute_name" do
 
       before do
-        command.class.parameter "FOO", "a foo", :attribute_name => :bar
+        command.class.parameter "FOO", "a foo", attribute_name: :bar
       end
 
       it "uses the specified attribute_name name to name accessors" do
@@ -565,7 +565,7 @@ describe Clamp::Command do
     context "with :default value" do
 
       before do
-        command.class.parameter "[ORIENTATION]", "direction", :default => "west"
+        command.class.parameter "[ORIENTATION]", "direction", default: "west"
       end
 
       it "sets the specified default value" do
@@ -636,8 +636,8 @@ describe Clamp::Command do
     context "with :environment_variable" do
 
       before do
-        command.class.parameter "[FILE]", "a file", :environment_variable => "FILE",
-                                                    :default => "/dev/null"
+        command.class.parameter "[FILE]", "a file", environment_variable: "FILE",
+                                                    default: "/dev/null"
       end
 
       let(:args) { [] }
@@ -715,7 +715,7 @@ describe Clamp::Command do
     before do
       command.class.parameter "X", "x\nxx"
       command.class.parameter "Y", "y"
-      command.class.parameter "[Z]", "z", :default => "ZZZ"
+      command.class.parameter "[Z]", "z", default: "ZZZ"
     end
 
     describe "#parse" do
@@ -882,7 +882,7 @@ describe Clamp::Command do
             print context[:foo]
           end
         end
-        command.class.run("xyz", [], :foo => "bar")
+        command.class.run("xyz", [], foo: "bar")
         expect(stdout).to eql "bar"
       end
 
@@ -894,7 +894,7 @@ describe Clamp::Command do
 
         command.class.class_eval do
           def execute
-            signal_error "Oh crap!", :status => 456
+            signal_error "Oh crap!", status: 456
           end
         end
 

--- a/spec/clamp/messages_spec.rb
+++ b/spec/clamp/messages_spec.rb
@@ -6,8 +6,8 @@ describe Clamp::Messages do
   describe "message" do
     before do
       Clamp.messages = {
-        :too_many_arguments => "Way too many!",
-        :custom_message => "Say %<what>s to %<whom>s"
+        too_many_arguments: "Way too many!",
+        custom_message: "Say %<what>s to %<whom>s"
       }
     end
 
@@ -24,7 +24,7 @@ describe Clamp::Messages do
     end
 
     it "formats the message" do
-      expect(Clamp.message(:custom_message, :what => "hello", :whom => "Clamp")).to eql "Say hello to Clamp"
+      expect(Clamp.message(:custom_message, what: "hello", whom: "Clamp")).to eql "Say hello to Clamp"
     end
   end
 
@@ -33,7 +33,7 @@ describe Clamp::Messages do
       default_msg = Clamp.message(:too_many_arguments).clone
 
       Clamp.messages = {
-        :too_many_arguments => "Way too many!"
+        too_many_arguments: "Way too many!"
       }
       Clamp.clear_messages!
 

--- a/spec/clamp/option/definition_spec.rb
+++ b/spec/clamp/option/definition_spec.rb
@@ -27,7 +27,7 @@ describe Clamp::Option::Definition do
       end
 
       it "can be overridden" do
-        option = described_class.new("--key-file", "FILE", "SSH identity", :attribute_name => "ssh_identity")
+        option = described_class.new("--key-file", "FILE", "SSH identity", attribute_name: "ssh_identity")
         expect(option.attribute_name).to eql "ssh_identity"
       end
 
@@ -49,7 +49,7 @@ describe Clamp::Option::Definition do
       end
 
       it "can be overridden" do
-        option = described_class.new("-n", "N", "iterations", :default => 1)
+        option = described_class.new("-n", "N", "iterations", default: 1)
         expect(option.default_value).to eql 1
       end
 
@@ -149,7 +149,7 @@ describe Clamp::Option::Definition do
   context "with an associated environment variable" do
 
     let(:option) do
-      described_class.new("-x", "X", "mystery option", :environment_variable => "APP_X")
+      described_class.new("-x", "X", "mystery option", environment_variable: "APP_X")
     end
 
     describe "#help" do
@@ -163,7 +163,7 @@ describe Clamp::Option::Definition do
     context "and a default value" do
 
       let(:option) do
-        described_class.new("-x", "X", "mystery option", :environment_variable => "APP_X", :default => "xyz")
+        described_class.new("-x", "X", "mystery option", environment_variable: "APP_X", default: "xyz")
       end
 
       describe "#help" do
@@ -181,7 +181,7 @@ describe Clamp::Option::Definition do
   context "multivalued" do
 
     let(:option) do
-      described_class.new(["-H", "--header"], "HEADER", "extra header", :multivalued => true)
+      described_class.new(["-H", "--header"], "HEADER", "extra header", multivalued: true)
     end
 
     it "is multivalued" do
@@ -195,7 +195,7 @@ describe Clamp::Option::Definition do
       end
 
       it "can be overridden" do
-        option = described_class.new("-H", "HEADER", "extra header", :multivalued => true, :default => [1, 2, 3])
+        option = described_class.new("-H", "HEADER", "extra header", multivalued: true, default: [1, 2, 3])
         expect(option.default_value).to eql [1, 2, 3]
       end
 
@@ -247,19 +247,19 @@ describe Clamp::Option::Definition do
     it "rejects :default" do
       expect do
         described_class.new("--key-file", "FILE", "SSH identity",
-                            :required => true, :default => "hello")
+                            required: true, default: "hello")
       end.to raise_error(ArgumentError)
     end
 
     it "rejects :flag options" do
       expect do
-        described_class.new("--awesome", :flag, "Be awesome?", :required => true)
+        described_class.new("--awesome", :flag, "Be awesome?", required: true)
       end.to raise_error(ArgumentError)
     end
   end
 
   describe "a hidden option" do
-    let(:option) { described_class.new("--unseen", :flag, "Something", :hidden => true) }
+    let(:option) { described_class.new("--unseen", :flag, "Something", hidden: true) }
     it "is hidden" do
       expect(option).to be_hidden
     end
@@ -268,7 +268,7 @@ describe Clamp::Option::Definition do
   describe "a hidden option in a command" do
     let(:command_class) do
       Class.new(Clamp::Command) do
-        option "--unseen", :flag, "Something", :hidden => true
+        option "--unseen", :flag, "Something", hidden: true
 
         def execute
           # this space intentionally left blank

--- a/spec/clamp/option_module_spec.rb
+++ b/spec/clamp/option_module_spec.rb
@@ -10,7 +10,7 @@ describe Clamp::Command do
 
       shared_options = Module.new do
         extend Clamp::Option::Declaration
-        option "--size", "SIZE", :default => 4
+        option "--size", "SIZE", default: 4
       end
 
       command_class = Class.new(Clamp::Command) do

--- a/spec/clamp/parameter/definition_spec.rb
+++ b/spec/clamp/parameter/definition_spec.rb
@@ -27,7 +27,7 @@ describe Clamp::Parameter::Definition do
       end
 
       it "can be overridden" do
-        parameter = described_class.new("COLOR", "hue of choice", :attribute_name => "hue")
+        parameter = described_class.new("COLOR", "hue of choice", attribute_name: "hue")
         expect(parameter.attribute_name).to eql "hue"
       end
 
@@ -145,7 +145,7 @@ describe Clamp::Parameter::Definition do
     context "with a weird parameter name, and an explicit attribute_name" do
 
       let(:parameter) do
-        described_class.new("KEY=VALUE ...", "config-settings", :attribute_name => :config_settings)
+        described_class.new("KEY=VALUE ...", "config-settings", attribute_name: :config_settings)
       end
 
       describe "#attribute_name" do
@@ -197,7 +197,7 @@ describe Clamp::Parameter::Definition do
     context "with specified default value" do
 
       let(:parameter) do
-        described_class.new("[FILES] ...", "files to process", :default => %w(a b c))
+        described_class.new("[FILES] ...", "files to process", default: %w(a b c))
       end
 
       describe "#default_value" do


### PR DESCRIPTION
Got carried away with #79 

Changes all occurences of `:sym => val` to `sym: val` everywhere.
