### PR TITLE
raise an error when a required, multivalued option is left blank

### DIFF
--- a/lib/clamp/option/parsing.rb
+++ b/lib/clamp/option/parsing.rb
@@ -52,8 +52,10 @@ module Clamp
 
       def verify_required_options_are_set
         self.class.recognised_options.each do |option|
-          # If this option is required and the value is nil, there's an error.
-          next unless option.required? && send(option.attribute_name).nil?
+          # If this option is required and the value is nil (or [] for multivalued), there's an error.
+          next unless option.required? &&
+		  (!option.multivalued? && send(option.attribute_name).nil?) ||
+		  (option.multivalued? && send(option.attribute_name).empty?)
           if option.environment_variable
             message = Clamp.message(:option_or_env_required,
                                     :option => option.switches.first,

--- a/spec/clamp/command_spec.rb
+++ b/spec/clamp/command_spec.rb
@@ -269,6 +269,34 @@ describe Clamp::Command do
 
     end
 
+    context "with :required and :multivalued" do
+
+      before do
+        command.class.option "--port", "PORT", "port to listen on", :required => true, :multivalued => true
+      end
+
+      context "when no value is provided" do
+
+        it "raises a UsageError" do
+          expect do
+            command.parse([])
+          end.to raise_error(Clamp::UsageError)
+        end
+
+      end
+
+      context "when a value is provided" do
+
+        it "does not raise an error" do
+          expect do
+            command.parse(["--port", "12345"])
+          end.not_to raise_error
+        end
+
+      end
+
+    end
+
     context "with a block" do
 
       before do


### PR DESCRIPTION
checking for nil? returns false on an empty Array which is the default
value for an multivalued option. also check for empty? in that case.