### PR TITLE
Calculate a good width for left column of help output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :development do
   gem "highline"
   gem "listen", "~> 3.0"
   gem "rake", "~> 12.3"
-  gem "rubocop", require: false
+  gem "rubocop", "~> 0.57.2", "<= 0.58", require: false
 end
 
 group :test do

--- a/spec/clamp/help_spec.rb
+++ b/spec/clamp/help_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Clamp::Help::Builder do
+
+  subject(:builder) { described_class.new }
+
+  def output
+    builder.string
+  end
+
+  describe "#line" do
+
+    it "adds a line of text" do
+      builder.line("blah")
+      expect(output).to eq("blah\n")
+    end
+
+  end
+
+  describe "#row" do
+
+    it "adds two strings separated by spaces" do
+      builder.row("LHS", "RHS")
+      expect(output).to eq("    LHS    RHS\n")
+    end
+
+  end
+
+  context "with multiple rows" do
+
+    it "arranges them in two columns" do
+      builder.row("foo", "bar")
+      builder.row("flibble", "blurk")
+      builder.row("x", "y")
+      expect(output.lines).to eq [
+        "    foo        bar\n",
+        "    flibble    blurk\n",
+        "    x          y\n"
+      ]
+    end
+
+  end
+
+  context "with a mixture of lines and rows" do
+
+    it "still arranges them in two columns" do
+      builder.line("ABCDEFGHIJKLMNOP")
+      builder.row("flibble", "blurk")
+      builder.line("Another section heading")
+      builder.row("x", "y")
+      expect(output.lines).to eq [
+        "ABCDEFGHIJKLMNOP\n",
+        "    flibble    blurk\n",
+        "Another section heading\n",
+        "    x          y\n"
+      ]
+    end
+
+  end
+
+end


### PR DESCRIPTION
Idea from #60

Sample help output, BEFORE:

```
$ be exe/swa
Usage:
    swa [OPTIONS] SUBCOMMAND [ARG] ...

Parameters:
    SUBCOMMAND                    subcommand
    [ARG] ...                     subcommand arguments

Subcommands:
    cf, cloudformation            CloudFormation stuff
    ec2                           EC2 stuff
    elb                           elb stuff
    iam                           IAM stuff
    kms                           KMS stuff
    s3                            S3 stuff

Options:
    -h, --help                    print help
    --region REGION               AWS region
    --access-key KEY              AWS access key
    --secret-key KEY              AWS secret key
    --session-token KEY           AWS security token
    --debug                       enable debugging
    --format FORMAT               format for data output (default: $SWA_OUTPUT_FORMAT, or "YAML")
    --json, -J                    output data in JSON format
    --yaml, -Y                    output data in YAML format
```

and AFTER:

```
$ be exe/swa
Usage:
    swa [OPTIONS] SUBCOMMAND [ARG] ...

Parameters:
    SUBCOMMAND             subcommand
    [ARG] ...              subcommand arguments

Subcommands:
    cf, cloudformation     CloudFormation stuff
    ec2                    EC2 stuff
    elb                    elb stuff
    iam                    IAM stuff
    kms                    KMS stuff
    s3                     S3 stuff

Options:
    -h, --help             print help
    --region REGION        AWS region
    --access-key KEY       AWS access key
    --secret-key KEY       AWS secret key
    --session-token KEY    AWS security token
    --debug                enable debugging
    --format FORMAT        format for data output (default: $SWA_OUTPUT_FORMAT, or "YAML")
    --json, -J             output data in JSON format
    --yaml, -Y             output data in YAML format
```