### PR TITLE
Resolve warnings from Ruby (MRI)

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,3 @@
 --color
+--format documentation
+--warnings

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,6 @@ task "default" => "spec"
 
 RSpec::Core::RakeTask.new do |t|
   t.pattern = "spec/**/*_spec.rb"
-  t.rspec_opts = ["--colour", "--format", "documentation"]
 end
 
 require "rubocop/rake_task"

--- a/lib/clamp/attribute/definition.rb
+++ b/lib/clamp/attribute/definition.rb
@@ -54,11 +54,11 @@ module Clamp
       end
 
       def required?
-        @required
+        @required ||= false
       end
 
       def hidden?
-        @hidden
+        @hidden ||= false
       end
 
       def attribute_name

--- a/lib/clamp/messages.rb
+++ b/lib/clamp/messages.rb
@@ -11,7 +11,8 @@ module Clamp #:nodoc:
     end
 
     def message(key, options = {})
-      format(messages.fetch(key), options)
+      string = messages.fetch(key)
+      options.any? ? format(string, options) : format(string)
     end
 
     def clear_messages!

--- a/lib/clamp/option/declaration.rb
+++ b/lib/clamp/option/declaration.rb
@@ -29,7 +29,7 @@ module Clamp
       end
 
       def recognised_options
-        unless @implicit_options_declared
+        unless @implicit_options_declared ||= false
           declare_implicit_help_option
           @implicit_options_declared = true
         end

--- a/lib/clamp/subcommand/declaration.rb
+++ b/lib/clamp/subcommand/declaration.rb
@@ -59,7 +59,7 @@ module Clamp
       private
 
       def declare_subcommand_parameters
-        if @default_subcommand
+        if @default_subcommand ||= false
           parameter "[SUBCOMMAND]", "subcommand",
                     attribute_name: :subcommand_name,
                     default: @default_subcommand,

--- a/lib/clamp/subcommand/definition.rb
+++ b/lib/clamp/subcommand/definition.rb
@@ -3,15 +3,13 @@
 module Clamp
   module Subcommand
 
-    Definition = Struct.new(:name, :description, :subcommand_class) do
+    Definition = Struct.new(:names, :description, :subcommand_class) do
 
       def initialize(names, description, subcommand_class)
-        @names = Array(names)
-        @description = description
-        @subcommand_class = subcommand_class
+        self[:names] = Array(names)
+        self[:description] = description
+        self[:subcommand_class] = subcommand_class
       end
-
-      attr_reader :names, :description, :subcommand_class
 
       def is_called?(name)
         names.member?(name)


### PR DESCRIPTION
Add `--warnings` option for RSpec.

Move `--format` option from `Rakefile` to `.rspec`.