### PR TITLE
Remove `type` of options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ require 'clamp'
 
 Clamp do
 
-  option "--loud", :flag, "say it loud"
-  option ["-n", "--iterations"], "N", "say it N times", default: 1 do |s|
+  option "--loud", "say it loud", flag: true
+  option ["-n", "--iterations"], "say it N times", default: 1 do |s|
     Integer(s)
   end
 
@@ -50,8 +50,8 @@ require 'clamp'
 
 class SpeakCommand < Clamp::Command
 
-  option "--loud", :flag, "say it loud"
-  option ["-n", "--iterations"], "N", "say it N times", default: 1 do |s|
+  option "--loud", "say it loud", flag: true
+  option ["-n", "--iterations"], "say it N times", default: 1 do |s|
     Integer(s)
   end
 
@@ -81,13 +81,12 @@ There are more examples demonstrating various features of Clamp [on Github][exam
 Options are declared using the `option` method.  The three required arguments are:
 
   1. the option switch (or switches),
-  2. an option argument name
-  3. a short description
+  2. a short description
 
 For example:
 
 ```ruby
-option "--flavour", "FLAVOUR", "ice-cream flavour"
+option "--flavour", "ice-cream flavour"
 ```
 
 It works a little like `attr_accessor`, defining reader and writer methods on the command class.  The attribute name is inferred from the switch (in this case, "`flavour`").  When you pass options to your command, Clamp will populate the attributes, which are then available for use in your `#execute` method.
@@ -101,8 +100,8 @@ end
 If you don't like the inferred attribute name, you can override it:
 
 ```ruby
-option "--type", "TYPE", "type of widget", attribute_name: :widget_type
-                                           # to avoid clobbering Object#type
+option "--type", "type of widget", attribute_name: :widget_type
+                                   # to avoid clobbering Object#type
 ```
 
 ### Short/long option switches
@@ -110,15 +109,15 @@ option "--type", "TYPE", "type of widget", attribute_name: :widget_type
 The first argument to `option` can be an array, rather than a single string, in which case all the switches are treated as aliases:
 
 ```ruby
-option ["-s", "--subject"], "SUBJECT", "email subject line"
+option ["-s", "--subject"], "email subject line"
 ```
 
 ### Flag options
 
-Some options are just boolean flags.  Pass "`:flag`" as the second parameter to tell Clamp not to expect an option argument:
+Some options are just boolean flags.  Pass "`flag: true`" in the third parameter to tell Clamp not to expect an option argument:
 
 ```ruby
-option "--verbose", :flag, "be chatty"
+option "--verbose", "be chatty", flag: true
 ```
 
 For flag options, Clamp appends "`?`" to the generated reader method; ie. you get a method called "`#verbose?`", rather than just "`#verbose`".
@@ -126,7 +125,7 @@ For flag options, Clamp appends "`?`" to the generated reader method; ie. you ge
 Negatable flags are easy to generate, too:
 
 ```ruby
-option "--[no-]force", :flag, "be forceful (or not)"
+option "--[no-]force", "be forceful (or not)", flag: true
 ```
 
 Clamp will handle both "`--force`" and "`--no-force`" options, setting the value of "`#force?`" appropriately.
@@ -136,7 +135,7 @@ Clamp will handle both "`--force`" and "`--no-force`" options, setting the value
 Although "required option" is an oxymoron, Clamp lets you mark an option as required, and will verify that a value is provided:
 
 ```ruby
-option "--password", "PASSWORD", "the secret password", required: true
+option "--password", "the secret password", required: true
 ```
 
 Note that it makes no sense to mark a `:flag` option, or one with a `:default`, as `:required`.
@@ -146,7 +145,7 @@ Note that it makes no sense to mark a `:flag` option, or one with a `:default`, 
 Declaring an option "`:multivalued`" allows it to be specified multiple times on the command line.
 
 ```ruby
-option "--format", "FORMAT", "output format", multivalued: true
+option "--format", "output format", multivalued: true
 ```
 
 The underlying attribute becomes an Array, and the suffix "`_list`" is appended to the default attribute name.  In this case, an attribute called "`format_list`" would be generated (unless you override the default by specifying an `:attribute_name`).
@@ -156,7 +155,7 @@ The underlying attribute becomes an Array, and the suffix "`_list`" is appended 
 Declaring an option "`:hidden`" will cause it to be hidden from `--help` output.
 
 ```ruby
-option "--some-option", "VALUE", "Just a little option", hidden: true
+option "--some-option", "Just a little option", hidden: true
 ```
 
 ### Version option
@@ -164,7 +163,7 @@ option "--some-option", "VALUE", "Just a little option", hidden: true
 A common idiom is to have an option `--version` that outputs the command version and doesn't run any subcommands.  This can be achieved by:
 
 ```ruby
-option "--version", :flag, "Show version" do
+option "--version", "Show version", flag: true do
   puts MyGem::VERSION
   exit(0)
 end
@@ -217,7 +216,7 @@ called with the raw string argument, and is expected to validate it.  The value 
 For example:
 
 ```ruby
-option "--port", "PORT", "port to listen on" do |s|
+option "--port", "port to listen on" do |s|
   Integer(s)
 end
 ```
@@ -259,7 +258,7 @@ end
 Default values can be specified for options, and optional parameters:
 
 ```ruby
-option "--flavour", "FLAVOUR", "ice-cream flavour", default: "chocolate"
+option "--flavour", "ice-cream flavour", default: "chocolate"
 
 parameter "[HOST]", "server host", default: "localhost"
 ```
@@ -267,9 +266,9 @@ parameter "[HOST]", "server host", default: "localhost"
 For more advanced cases, you can also specify default values by defining a method called "`default_#{attribute_name}`":
 
 ```ruby
-option "--http-port", "PORT", "web-server port", default:  9000
+option "--http-port", "web-server port", default:  9000
 
-option "--admin-port", "PORT", "admin port"
+option "--admin-port", "admin port"
 
 def default_admin_port
    http_port + 1
@@ -281,7 +280,7 @@ end
 Options (and optional parameters) can also be associated with environment variables:
 
 ```ruby
-option "--port", "PORT", "the port to listen on", environment_variable: "MYAPP_PORT" do |val|
+option "--port", "the port to listen on", environment_variable: "MYAPP_PORT" do |val|
   val.to_i
 end
 
@@ -409,7 +408,7 @@ Arguments:
 
 Options:
     --loud                        say it loud
-    -n, --iterations N            say it N times (default: 1)
+    -n, --iterations              say it N times (default: 1)
     -h, --help                    print help
 ```
 

--- a/examples/admin
+++ b/examples/admin
@@ -7,7 +7,7 @@ require "clamp"
 
 Clamp do
 
-  option "--timeout", "SECONDS", "connection timeout", default: 5, environment_variable: "MYAPP_TIMEOUT" do |x|
+  option "--timeout", "connection timeout", default: 5, environment_variable: "MYAPP_TIMEOUT" do |x|
     Integer(x)
   end
 

--- a/examples/defaulted
+++ b/examples/defaulted
@@ -8,10 +8,10 @@ require "highline"
 
 Clamp do
 
-  option ["-U", "--user"], "USER", "user name",
+  option ["-U", "--user"], "user name",
          environment_variable: "THE_USER",
          default: "bob"
-  option ["-P", "--password"], "PASSWORD", "password",
+  option ["-P", "--password"], "password",
          environment_variable: "THE_PASSWORD"
 
   def execute

--- a/examples/flipflop
+++ b/examples/flipflop
@@ -8,7 +8,7 @@ require "clamp/version"
 
 Clamp do
 
-  option ["--version", "-v"], :flag, "Show version" do
+  option ["--version", "-v"], "Show version", flag: true do
     puts "Powered by Clamp-#{Clamp::VERSION}"
     exit(0)
   end

--- a/examples/gitdown
+++ b/examples/gitdown
@@ -9,9 +9,9 @@ module GitDown
 
   class AbstractCommand < Clamp::Command
 
-    option ["-v", "--verbose"], :flag, "be verbose"
+    option ["-v", "--verbose"], "be verbose", flag: true
 
-    option "--version", :flag, "show version" do
+    option "--version", "show version", flag: true do
       puts "GitDown-0.0.0a"
       exit(0)
     end
@@ -36,7 +36,7 @@ module GitDown
 
   class PullCommand < AbstractCommand
 
-    option "--[no-]commit", :flag, "Perform the merge and commit the result."
+    option "--[no-]commit", "Perform the merge and commit the result.", flag: true
 
     def execute
       say "pulling"
@@ -46,7 +46,7 @@ module GitDown
 
   class StatusCommand < AbstractCommand
 
-    option ["-s", "--short"], :flag, "Give the output in the short-format."
+    option ["-s", "--short"], "Give the output in the short-format.", flag: true
 
     def execute
       if short?

--- a/examples/scoop
+++ b/examples/scoop
@@ -7,7 +7,7 @@ require "clamp"
 
 Clamp do
 
-  option ["-f", "--flavour"], "FLAVOUR", "flavour",
+  option ["-f", "--flavour"], "flavour",
          multivalued: true, default: ["chocolate"],
          attribute_name: :flavours
 

--- a/examples/speak
+++ b/examples/speak
@@ -11,8 +11,8 @@ Clamp do
     Say something.
   )
 
-  option "--loud", :flag, "say it loud"
-  option ["-n", "--iterations"], "N", "say it N times", default: 1 do |s|
+  option "--loud", "say it loud", flag: true
+  option ["-n", "--iterations"], "say it N times", default: 1 do |s|
     Integer(s)
   end
 

--- a/lib/clamp/option/declaration.rb
+++ b/lib/clamp/option/declaration.rb
@@ -12,8 +12,8 @@ module Clamp
 
       include Clamp::Attribute::Declaration
 
-      def option(switches, type, description, opts = {}, &block)
-        Option::Definition.new(switches, type, description, opts).tap do |option|
+      def option(switches, description, opts = {}, &block)
+        Option::Definition.new(switches, description, opts).tap do |option|
           block ||= option.default_conversion_block
           define_accessors_for(option, &block)
           declared_options << option
@@ -42,7 +42,7 @@ module Clamp
         return false if effective_options.find { |o| o.handles?("--help") }
         help_switches = ["--help"]
         help_switches.unshift("-h") unless effective_options.find { |o| o.handles?("-h") }
-        option help_switches, :flag, "print help" do
+        option help_switches, "print help", flag: true do
           request_help
         end
       end

--- a/lib/clamp/option/parsing.rb
+++ b/lib/clamp/option/parsing.rb
@@ -54,7 +54,7 @@ module Clamp #:nodoc:
         case switch
         when /\A(-\w)(.+)\z/m # combined short options
           switch = Regexp.last_match(1)
-          if find_option(switch).flag?
+          if find_option(switch).flag
             remaining_arguments.unshift("-" + Regexp.last_match(2))
           else
             remaining_arguments.unshift(Regexp.last_match(2))

--- a/spec/clamp/command_group_spec.rb
+++ b/spec/clamp/command_group_spec.rb
@@ -275,12 +275,12 @@ describe Clamp::Command do
 
       speed_options = Module.new do
         extend Clamp::Option::Declaration
-        option "--speed", "SPEED", "how fast", default: "slowly"
+        option "--speed", "how fast", default: "slowly"
       end
 
       Class.new(Clamp::Command) do
 
-        option "--direction", "DIR", "which way", default: "home"
+        option "--direction", "which way", default: "home"
 
         include speed_options
 
@@ -326,7 +326,7 @@ describe Clamp::Command do
   context "with a subcommand, with options" do
 
     given_command "weeheehee" do
-      option "--json", "JSON", "a json blob" do |option|
+      option "--json", "a json blob" do |option|
         print "parsing!"
         option
       end
@@ -401,7 +401,7 @@ describe Clamp::Command do
   context "with a subcommand and required options" do
 
     given_command "movements" do
-      option "--direction", "N|S|E|W", "bearing", required: true
+      option "--direction", "bearing", required: true
       subcommand "hop", "Hop" do
         def execute
           puts "Hopping #{direction}"

--- a/spec/clamp/command_spec.rb
+++ b/spec/clamp/command_spec.rb
@@ -39,16 +39,16 @@ describe Clamp::Command do
   describe ".option" do
 
     it "declares option argument accessors" do
-      command.class.option "--flavour", "FLAVOUR", "Flavour of the month"
+      command.class.option "--flavour", "Flavour of the month"
       expect(command.flavour).to eql nil
       command.flavour = "chocolate"
       expect(command.flavour).to eql "chocolate"
     end
 
-    context "with type :flag" do
+    context "with :flag option" do
 
       before do
-        command.class.option "--verbose", :flag, "Be heartier"
+        command.class.option "--verbose", "Be heartier", flag: true
       end
 
       it "declares a predicate-style reader" do
@@ -61,7 +61,7 @@ describe Clamp::Command do
     context "with explicit :attribute_name" do
 
       before do
-        command.class.option "--foo", "FOO", "A foo", attribute_name: :bar
+        command.class.option "--foo", "A foo", attribute_name: :bar
       end
 
       it "uses the specified attribute_name name to name accessors" do
@@ -79,7 +79,7 @@ describe Clamp::Command do
     context "with default method" do
 
       before do
-        command.class.option "--port", "PORT", "port"
+        command.class.option "--port", "port"
         command.class.class_eval do
           def default_port
             4321
@@ -96,7 +96,7 @@ describe Clamp::Command do
     context "with :default value" do
 
       before do
-        command.class.option "--port", "PORT", "port to listen on", default: 4321
+        command.class.option "--port", "port to listen on", default: 4321
       end
 
       it "declares default method" do
@@ -116,7 +116,7 @@ describe Clamp::Command do
     context "without :default value" do
 
       before do
-        command.class.option "--port", "PORT", "port to listen on"
+        command.class.option "--port", "port to listen on"
       end
 
       it "does not declare default method" do
@@ -128,7 +128,7 @@ describe Clamp::Command do
     context "with :multivalued" do
 
       before do
-        command.class.option "--flavour", "FLAVOUR", "flavour(s)", multivalued: true, attribute_name: :flavours
+        command.class.option "--flavour", "flavour(s)", multivalued: true, attribute_name: :flavours
       end
 
       it "defaults to empty array" do
@@ -166,7 +166,7 @@ describe Clamp::Command do
       let(:args) { [] }
 
       before do
-        command.class.option "--port", "PORT", "port to listen on",
+        command.class.option "--port", "port to listen on",
                              default: 4321,
                              environment_variable: "PORT",
                              &:to_i
@@ -212,12 +212,12 @@ describe Clamp::Command do
 
     end
 
-    context "with :environment_variable and type :flag" do
+    context "with :environment_variable and :flag option" do
 
       let(:environment_value) { nil }
 
       before do
-        command.class.option "--[no-]enable", :flag, "enable?", default: false, environment_variable: "ENABLE"
+        command.class.option "--[no-]enable", "enable?", flag: true, default: false, environment_variable: "ENABLE"
         set_env("ENABLE", environment_value)
         command.parse([])
       end
@@ -263,7 +263,7 @@ describe Clamp::Command do
     context "with :required" do
 
       before do
-        command.class.option "--port", "PORT", "port to listen on", required: true
+        command.class.option "--port", "port to listen on", required: true
       end
 
       describe "#help" do
@@ -299,7 +299,7 @@ describe Clamp::Command do
     context "with :required and :multivalued" do
 
       before do
-        command.class.option "--port", "PORT", "port to listen on", required: true, multivalued: true
+        command.class.option "--port", "port to listen on", required: true, multivalued: true
       end
 
       context "when no value is provided" do
@@ -327,7 +327,7 @@ describe Clamp::Command do
     context "with a block" do
 
       before do
-        command.class.option "--port", "PORT", "Port to listen on" do |port|
+        command.class.option "--port", "Port to listen on" do |port|
           Integer(port)
         end
       end
@@ -347,14 +347,14 @@ describe Clamp::Command do
   context "with options declared" do
 
     before do
-      command.class.option ["-f", "--flavour"], "FLAVOUR", "Flavour of the month"
-      command.class.option ["-c", "--color"], "COLOR", "Preferred hue"
-      command.class.option ["--scoops"], "N", "Number of scoops",
+      command.class.option ["-f", "--flavour"], "Flavour of the month"
+      command.class.option ["-c", "--color"], "Preferred hue"
+      command.class.option ["--scoops"], "Number of scoops",
                            default: 1,
                            environment_variable: "DEFAULT_SCOOPS" do |arg|
         Integer(arg)
       end
-      command.class.option ["-n", "--[no-]nuts"], :flag, "Nuts (or not)\nMay include nuts"
+      command.class.option ["-n", "--[no-]nuts"], "Nuts (or not)\nMay include nuts", flag: true
       command.class.parameter "[ARG] ...", "extra arguments", attribute_name: :arguments
     end
 
@@ -555,8 +555,8 @@ describe Clamp::Command do
       end
 
       it "includes option details" do
-        expect(command.help).to match(/--flavour FLAVOUR +Flavour of the month/)
-        expect(command.help).to match(/--color COLOR +Preferred hue/)
+        expect(command.help).to match(/--flavour +Flavour of the month/)
+        expect(command.help).to match(/--color +Preferred hue/)
       end
 
       it "handles new lines in option descriptions" do
@@ -570,7 +570,7 @@ describe Clamp::Command do
   context "with an explicit --help option declared" do
 
     before do
-      command.class.option ["--help"], :flag, "help wanted"
+      command.class.option ["--help"], "help wanted", flag: true
     end
 
     it "does not generate implicit help option" do
@@ -591,7 +591,7 @@ describe Clamp::Command do
   context "with an explicit -h option declared" do
 
     before do
-      command.class.option ["-h", "--humidity"], "PERCENT", "relative humidity" do |n|
+      command.class.option ["-h", "--humidity"], "relative humidity" do |n|
         Integer(n)
       end
     end
@@ -1046,10 +1046,10 @@ describe Clamp::Command do
 
     let(:command) do
       parent_command_class = Class.new(Clamp::Command) do
-        option "--verbose", :flag, "be louder"
+        option "--verbose", "be louder", flag: true
       end
       derived_command_class = Class.new(parent_command_class) do
-        option "--iterations", "N", "number of times to go around"
+        option "--iterations", "number of times to go around"
       end
       derived_command_class.new("cmd")
     end

--- a/spec/clamp/option_reordering_spec.rb
+++ b/spec/clamp/option_reordering_spec.rb
@@ -19,11 +19,11 @@ describe Clamp::Command do
 
     given_command("cmd") do
 
-      option ["-v", "--verbose"], :flag, "Be noisy"
+      option ["-v", "--verbose"], "Be noisy", flag: true
 
       subcommand "say", "Say something" do
 
-        option "--loud", :flag, "say it loud"
+        option "--loud", "say it loud", flag: true
 
         parameter "WORDS ...", "the thing to say", attribute_name: :words
 


### PR DESCRIPTION
I don't know why it's here, it looks useless.

Make `:flag` an option (of option) with default `false`.

It's breaking changes, yes.