### PR TITLE
Add `pry-byebug` development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development do
   gem "guard-rspec", "~> 4.7", require: false
   gem "highline"
   gem "listen", "~> 3.0"
+  gem "pry-byebug", "~> 3.9"
   gem "rake", "~> 13.0"
   gem "rubocop", "~> 0.89.0", require: false
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require "rspec"
 require "clamp"
 require "stringio"
+require "pry-byebug"
 
 RSpec.configure do |config|
 


### PR DESCRIPTION
It allows to use `binding.pry` anywhere (in specs).