### PR TITLE
Print env var as default for required options

### DIFF
--- a/lib/clamp/attribute/definition.rb
+++ b/lib/clamp/attribute/definition.rb
@@ -20,8 +20,8 @@ module Clamp
 
       def help_rhs
         rhs = description
-        comments = required_indicator || default_description
-        rhs += " (#{comments})" if comments
+        comments = [required_indicator, default_description].compact
+        rhs += " (#{comments.join(', ')})" unless comments.empty?
         rhs
       end
 

--- a/spec/clamp/option/definition_spec.rb
+++ b/spec/clamp/option/definition_spec.rb
@@ -178,6 +178,22 @@ describe Clamp::Option::Definition do
 
     end
 
+    context "and is required" do
+
+      let(:option) do
+        described_class.new("-x", "X", "mystery option", environment_variable: "APP_X", required: true)
+      end
+
+      describe "#help" do
+
+        it "describes the environment variable as the default" do
+          expect(option.help).to eql ["-x X", %{mystery option (required, default: $APP_X)}]
+        end
+
+      end
+
+    end
+
   end
 
   context "multivalued" do


### PR DESCRIPTION
If an option is both required and has an environment variable specified, print that environment variable as the default in the help message.

This is @abirdZendesk's fix (from https://github.com/krav/clamp/pull/1) with an added spec.

Fixes #111.