### PR TITLE
Avoid Ruby 4 in gem specs

### DIFF
--- a/clamp.gemspec
+++ b/clamp.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = "~> 2.4"
+  s.required_ruby_version = ">= 2.4", "< 4"
 end


### PR DESCRIPTION
Even though old variant should work, the new one is more explicit.