### PR TITLE
Replace git ls-files with Dir globs in gemspec

### DIFF
--- a/clamp.gemspec
+++ b/clamp.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     It handles parsing of command-line options, and generation of usage help.
   TEXT
 
-  s.files         = `git ls-files`.split("\n")
+  s.files = Dir["lib/**/*", "examples/**/*", "spec/**/*", "*.md", "LICENSE", "Rakefile", "Gemfile", "#{s.name}.gemspec"]
   s.require_paths = ["lib"]
 
   s.required_ruby_version = ">= 2.5", "< 5"


### PR DESCRIPTION
## Summary

This PR replaces `git ls-files` with explicit `Dir` globs in the gemspec, following Ruby packaging best practices.

Fixes #125

## Changes

**Modified `clamp.gemspec` line 23:**

```ruby
# Before
s.files = `git ls-files`.split("\n")

# After
s.files = Dir["lib/**/*", "examples/**/*", "spec/**/*", "*.md", "LICENSE", "Rakefile", "Gemfile", "#{s.name}.gemspec"]
```

## Why This Change?

Using `git ls-files` in gemspecs is considered **bad practice** by the Ruby community:

### Problem 1: Git dependency breaks builds

- ❌ **Package builds**: Fails in Debian/RPM clean environments without git
- ❌ **Docker**: Breaks in minimal production images
- ❌ **Git archives**: Fails with GitHub release tarballs (no `.git/` directory)

### Problem 2: Includes unnecessary files

Current gem includes development files that bloat the package:
- `.github/workflows/ci.yml`
- `.rubocop.yml`, `.rspec`, `.autotest`, `.editorconfig`
- `CODEOWNERS`, `Guardfile`

## Benefits

✅ **No git dependency** - Works in all build environments
✅ **Explicit file list** - Clear, maintainable, intentional
✅ **Cleaner gems** - Production-ready files only
✅ **Simpler downstream packaging** - No manual exclusion lists needed
✅ **No breaking changes** - All necessary files still included

## Verification

Tested locally by building and unpacking the gem:

```bash
gem build clamp.gemspec
gem unpack clamp-1.4.0.gem
ls -la clamp-1.4.0/  # ✓ No .github/, no dotfiles
```

**Files included (clean):**
- `lib/` (source code)
- `examples/` (examples)
- `spec/` (tests)
- `CHANGES.md`, `README.md` (documentation)
- `LICENSE`, `Rakefile`, `Gemfile`, `clamp.gemspec`

**Files excluded (as intended):**
- `.github/`, `.rubocop.yml`, `.rspec`, `.autotest`, etc.
- `CODEOWNERS`, `Guardfile`

## Community Recommendations

This approach is recommended by:

- [Ruby Packaging Style Guide](https://packaging.rubystyle.guide/)
- [RuboCop Packaging cops](https://docs.rubocop.org/rubocop-packaging/cops_packaging.html)
- [Bundler #2287: "`git ls-files` is bad practice"](https://github.com/rubygems/bundler/issues/2287)
- [ruby-progressbar #54: "Don't rely on git ls-files"](https://github.com/jfelchner/ruby-progressbar/issues/54)

## Real-world Impact

This issue was discovered during RPM packaging for the [Foreman project](https://github.com/theforeman/foreman-packaging/pull/13012), where the Travis CI → GitHub Actions migration broke builds because the spec file couldn't keep up with upstream changes.

This change eliminates that maintenance burden for all downstream packagers.
